### PR TITLE
Random eviction support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,4 @@ license = "MIT/Apache-2.0"
 travis-ci = { repository = "jonhoo/rust-evmap" }
 
 [dependencies]
-rahashmap = "0.2.1"
+rahashmap = { git = "https://github.com/ms705/rahashmap.git", branch = "no-reorder" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,4 @@ license = "MIT/Apache-2.0"
 travis-ci = { repository = "jonhoo/rust-evmap" }
 
 [dependencies]
-rahashmap = { git = "https://github.com/ms705/rahashmap.git", branch = "no-reorder" }
+rahashmap = { git = "https://github.com/fintelia/rahashmap.git", branch = "no-reorder" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,4 @@ license = "MIT/Apache-2.0"
 travis-ci = { repository = "jonhoo/rust-evmap" }
 
 [dependencies]
+rahashmap = "0.2.1"

--- a/src/inner.rs
+++ b/src/inner.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use rahashmap::HashMap;
 use std::hash::{BuildHasher, Hash};
 use std::sync::{atomic, Arc, Mutex};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,6 +181,8 @@
 //!
 #![deny(missing_docs)]
 
+extern crate rahashmap;
+
 use std::collections::hash_map::RandomState;
 use std::hash::{BuildHasher, Hash};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,6 +195,7 @@ enum Operation<K, V> {
     Add(K, V),
     Remove(K, V),
     Empty(K),
+    EmptyRandom(usize),
     Clear(K),
 }
 

--- a/src/write.rs
+++ b/src/write.rs
@@ -333,10 +333,11 @@ where
     /// The value-set will only disappear from readers after the next call to `refresh()`.
     pub fn empty_at_index(&mut self, index: usize) -> Option<(&K, &Vec<V>)> {
         self.add_op(Operation::EmptyRandom(index));
-        // it's okay to fetch the entries second, since we won't drop them until refresh() is
-        // called
-        let inner = &*self.w_handle.as_ref().unwrap();
-        inner.data.at_index(index)
+        // the actual emptying won't happen until refresh(), which needs &mut self
+        // so it's okay for us to return the references here
+        self.w_handle
+            .as_ref()
+            .and_then(|inner| inner.data.at_index(index))
     }
 
     fn apply_first(inner: &mut Inner<K, V, M, S>, op: &mut Operation<K, V>) {

--- a/src/write.rs
+++ b/src/write.rs
@@ -332,10 +332,11 @@ where
     /// This is effectively random removal
     /// The value-set will only disappear from readers after the next call to `refresh()`.
     pub fn empty_at_index(&mut self, index: usize) -> Option<(&K, &Vec<V>)> {
-        let inner = self.r_handle.inner.load(atomic::Ordering::SeqCst);
         self.add_op(Operation::EmptyRandom(index));
-        // ok to do second as we haven't refreshed yet
-        unsafe { (*inner).data.at_index(index) }
+        // it's okay to fetch the entries second, since we won't drop them until refresh() is
+        // called
+        let inner = &*self.w_handle.as_ref().unwrap();
+        inner.data.at_index(index)
     }
 
     fn apply_first(inner: &mut Inner<K, V, M, S>, op: &mut Operation<K, V>) {

--- a/src/write.rs
+++ b/src/write.rs
@@ -331,8 +331,11 @@ where
     ///
     /// This is effectively random removal
     /// The value-set will only disappear from readers after the next call to `refresh()`.
-    pub fn empty_at_index(&mut self, index: usize) {
+    pub fn empty_at_index(&mut self, index: usize) -> Option<(&K, &Vec<V>)> {
+        let inner = self.r_handle.inner.load(atomic::Ordering::SeqCst);
         self.add_op(Operation::EmptyRandom(index));
+        // ok to do second as we haven't refreshed yet
+        unsafe { (*inner).data.at_index(index) }
     }
 
     fn apply_first(inner: &mut Inner<K, V, M, S>, op: &mut Operation<K, V>) {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -251,6 +251,23 @@ fn empty() {
 }
 
 #[test]
+fn empty_random() {
+    let (r, mut w) = evmap::new();
+    w.insert(1, "a");
+    w.insert(1, "b");
+    w.insert(2, "c");
+    w.empty_at_index(0);
+    w.refresh();
+
+    // should only have one value set left
+    assert_eq!(r.len(), 1);
+    // one of them must have gone away
+    assert!(
+        (!r.contains_key(&1) && r.contains_key(&2)) || (r.contains_key(&1) && !r.contains_key(&2))
+    );
+}
+
+#[test]
 fn empty_post_refresh() {
     let (r, mut w) = evmap::new();
     w.insert(1, "a");


### PR DESCRIPTION
Moves to `rahashmap` for the underlying storage and adds support for random key eviction.

Maybe merge in a branch to insulate consumers against changes that break `rahashmap` (which seem relatively common).