### PR TITLE
Add optional features that can potentially improve performance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,6 @@ hashbrown = { version = "0.1.8", optional = true }
 smallvec = { version = "0.6.7", optional = true }
 
 [features]
-default = []
+default = ["hashbrown", "smallvec"]
 nightly_hashbrown = ["hashbrown/nightly"]
 nightly_smallvec = ["smallvec/union"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,9 @@ maintenance = { status = "passively-maintained" }
 
 [dependencies]
 hashbrown = { version = "0.1.8", optional = true }
-parking_lot = { version = "0.7.1", optional = true }
 smallvec = { version = "0.6.7", optional = true }
 
 [features]
 default = []
 nightly_hashbrown = ["hashbrown/nightly"]
-nightly_parking_lot = ["parking_lot/nightly"]
 nightly_smallvec = ["smallvec/union"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,12 @@ travis-ci = { repository = "jonhoo/rust-evmap" }
 maintenance = { status = "passively-maintained" }
 
 [dependencies]
+hashbrown = { version = "0.1.8", optional = true }
+parking_lot = { version = "0.7.1", optional = true }
+smallvec = { version = "0.6.7", optional = true }
+
+[features]
+default = []
+nightly_hashbrown = ["hashbrown/nightly"]
+nightly_parking_lot = ["parking_lot/nightly"]
+nightly_smallvec = ["smallvec/union"]

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Jon Gjengset <jon@thesquareplanet.com>"]
 
 [dependencies]
-evmap = { path = "../", features = ["hashbrown", "smallvec"] }
+evmap = { path = "../" }
 chashmap = "2.1.0"
 clap = "2.20.3"
 zipf = "0.2.0"

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Jon Gjengset <jon@thesquareplanet.com>"]
 
 [dependencies]
-evmap = { path = "../", features = ["hashbrown", "parking_lot", "smallvec"] }
+evmap = { path = "../", features = ["hashbrown", "smallvec"] }
 chashmap = "2.1.0"
 clap = "2.20.3"
 zipf = "0.2.0"
@@ -18,4 +18,4 @@ codegen-units = 1
 debug = false
 
 [features]
-nightly = ["evmap/nightly_hashbrown", "evmap/nightly_parking_lot", "evmap/nightly_smallvec"]
+nightly = ["evmap/nightly_hashbrown", "evmap/nightly_smallvec"]

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -11,9 +11,6 @@ zipf = "0.2.0"
 rand = "0.3"
 parking_lot = "0.7.1"
 
-[target.'cgf(not(target_env = "msvc"))'.dependencies]
-jemallocator = {version = "0.1.9", optional = true }
-
 [profile.release]
 lto = true
 opt-level = 3
@@ -21,4 +18,4 @@ codegen-units = 1
 debug = false
 
 [features]
-nightly = ["evmap/nightly_hashbrown", "evmap/nightly_parking_lot", "evmap/nightly_smallvec", "jemallocator"]
+nightly = ["evmap/nightly_hashbrown", "evmap/nightly_parking_lot", "evmap/nightly_smallvec"]

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -4,11 +4,21 @@ version = "0.1.0"
 authors = ["Jon Gjengset <jon@thesquareplanet.com>"]
 
 [dependencies]
-evmap = { path = "../" }
+evmap = { path = "../", features = ["hashbrown", "parking_lot", "smallvec"] }
 chashmap = "2.1.0"
 clap = "2.20.3"
 zipf = "0.2.0"
 rand = "0.3"
+parking_lot = "0.7.1"
+
+[target.'cgf(not(target_env = "msvc"))'.dependencies]
+jemallocator = {version = "0.1.9", optional = true }
 
 [profile.release]
-debug = true
+lto = true
+opt-level = 3
+codegen-units = 1
+debug = false
+
+[features]
+nightly = ["evmap/nightly_hashbrown", "evmap/nightly_parking_lot", "evmap/nightly_smallvec", "jemallocator"]

--- a/benchmark/src/main.rs
+++ b/benchmark/src/main.rs
@@ -6,13 +6,6 @@ extern crate rand;
 extern crate zipf;
 extern crate parking_lot;
 
-#[cfg(all(not(target_env = "msvc"), feature = "nightly"))]
-extern crate jemallocator;
-
-#[cfg(all(not(target_env = "msvc"), feature = "nightly"))]
-#[global_allocator]
-static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
-
 use chashmap::CHashMap;
 use std::collections::HashMap;
 use clap::{App, Arg};

--- a/benchmark/src/main.rs
+++ b/benchmark/src/main.rs
@@ -4,6 +4,14 @@ extern crate clap;
 extern crate evmap;
 extern crate rand;
 extern crate zipf;
+extern crate parking_lot;
+
+#[cfg(all(not(target_env = "msvc"), feature = "nightly"))]
+extern crate jemallocator;
+
+#[cfg(all(not(target_env = "msvc"), feature = "nightly"))]
+#[global_allocator]
+static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 use chashmap::CHashMap;
 use std::collections::HashMap;
@@ -135,7 +143,7 @@ fn main() {
         let (r, w) = evmap::Options::default()
             .with_capacity(5_000_000)
             .construct();
-        let w = sync::Arc::new(sync::Mutex::new((w, 0, refresh)));
+        let w = sync::Arc::new(parking_lot::Mutex::new((w, 0, refresh)));
         let start = time::Instant::now();
         let end = start + dur;
         join.extend((0..readers).into_iter().map(|_| {
@@ -218,7 +226,7 @@ impl Backend for sync::Arc<sync::RwLock<HashMap<u64, u64>>> {
 
 enum EvHandle {
     Read(evmap::ReadHandle<u64, u64>),
-    Write(sync::Arc<sync::Mutex<(evmap::WriteHandle<u64, u64>, usize, usize)>>),
+    Write(sync::Arc<parking_lot::Mutex<(evmap::WriteHandle<u64, u64>, usize, usize)>>),
 }
 
 impl Backend for EvHandle {
@@ -232,7 +240,7 @@ impl Backend for EvHandle {
 
     fn b_put(&mut self, key: u64, value: u64) {
         if let EvHandle::Write(ref w) = *self {
-            let mut w = w.lock().unwrap();
+            let mut w = w.lock();
             w.0.update(key, value);
             w.1 += 1;
             if w.1 == w.2 {

--- a/benchmark/src/main.rs
+++ b/benchmark/src/main.rs
@@ -88,7 +88,7 @@ fn main() {
     // first, benchmark Arc<RwLock<HashMap>>
     if matches.is_present("compare") {
         let map: HashMap<u64, u64> = HashMap::with_capacity(5_000_000);
-        let map = sync::Arc::new(sync::RwLock::new(map));
+        let map = sync::Arc::new(parking_lot::RwLock::new(map));
         let start = time::Instant::now();
         let end = start + dur;
         join.extend((0..readers).into_iter().map(|_| {
@@ -207,13 +207,13 @@ impl Backend for sync::Arc<CHashMap<u64, u64>> {
     }
 }
 
-impl Backend for sync::Arc<sync::RwLock<HashMap<u64, u64>>> {
+impl Backend for sync::Arc<parking_lot::RwLock<HashMap<u64, u64>>> {
     fn b_get(&self, key: u64) -> u64 {
-        self.read().unwrap().get(&key).map(|&v| v).unwrap_or(0)
+        self.read().get(&key).map(|&v| v).unwrap_or(0)
     }
 
     fn b_put(&mut self, key: u64, value: u64) {
-        self.write().unwrap().insert(key, value);
+        self.write().insert(key, value);
     }
 }
 

--- a/src/inner.rs
+++ b/src/inner.rs
@@ -1,17 +1,11 @@
+use std::hash::{BuildHasher, Hash};
+use std::sync::{atomic, Arc, Mutex};
+
 #[cfg(not(feature = "hashbrown"))]
 use std::collections::HashMap;
 
 #[cfg(feature = "hashbrown")]
 use hashbrown::HashMap;
-
-use std::hash::{BuildHasher, Hash};
-use std::sync::{atomic, Arc};
-
-#[cfg(not(feature = "parking_lot"))]
-use std::sync::Mutex;
-
-#[cfg(feature = "parking_lot")]
-use parking_lot::Mutex;
 
 #[cfg(not(feature = "smallvec"))]
 pub(crate) type Values<T> = Vec<T>;

--- a/src/inner.rs
+++ b/src/inner.rs
@@ -14,17 +14,17 @@ use std::sync::Mutex;
 use parking_lot::Mutex;
 
 #[cfg(not(feature = "smallvec"))]
-pub(crate) type Log<T> = Vec<T>;
+pub(crate) type Values<T> = Vec<T>;
 
 #[cfg(feature = "smallvec")]
-pub(crate) type Log<T> = smallvec::SmallVec<[T; 1]>;
+pub(crate) type Values<T> = smallvec::SmallVec<[T; 1]>;
 
 pub(crate) struct Inner<K, V, M, S>
 where
     K: Eq + Hash,
     S: BuildHasher,
 {
-    pub(crate) data: HashMap<K, Log<V>, S>,
+    pub(crate) data: HashMap<K, Values<V>, S>,
     pub(crate) epochs: Arc<Mutex<Vec<Arc<atomic::AtomicUsize>>>>,
     pub(crate) meta: M,
     ready: bool,

--- a/src/inner.rs
+++ b/src/inner.rs
@@ -1,13 +1,30 @@
+#[cfg(not(feature = "hashbrown"))]
 use std::collections::HashMap;
+
+#[cfg(feature = "hashbrown")]
+use hashbrown::HashMap;
+
 use std::hash::{BuildHasher, Hash};
-use std::sync::{atomic, Arc, Mutex};
+use std::sync::{atomic, Arc};
+
+#[cfg(not(feature = "parking_lot"))]
+use std::sync::Mutex;
+
+#[cfg(feature = "parking_lot")]
+use parking_lot::Mutex;
+
+#[cfg(not(feature = "smallvec"))]
+pub(crate) type Log<T> = Vec<T>;
+
+#[cfg(feature = "smallvec")]
+pub(crate) type Log<T> = smallvec::SmallVec<[T; 1]>;
 
 pub(crate) struct Inner<K, V, M, S>
 where
     K: Eq + Hash,
     S: BuildHasher,
 {
-    pub(crate) data: HashMap<K, Vec<V>, S>,
+    pub(crate) data: HashMap<K, Log<V>, S>,
     pub(crate) epochs: Arc<Mutex<Vec<Arc<atomic::AtomicUsize>>>>,
     pub(crate) meta: M,
     ready: bool,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,9 +184,6 @@
 //!
 #![deny(missing_docs)]
 
-#[cfg(feature = "parking_lot")]
-extern crate parking_lot;
-
 #[cfg(feature = "hashbrown")]
 extern crate hashbrown;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,7 +184,23 @@
 //!
 #![deny(missing_docs)]
 
-use std::collections::hash_map::RandomState;
+#[cfg(feature = "parking_lot")]
+extern crate parking_lot;
+
+#[cfg(feature = "hashbrown")]
+extern crate hashbrown;
+
+#[cfg(feature = "smallvec")]
+extern crate smallvec;
+
+/// Re-export default hash builder
+#[cfg(feature = "hashbrown")]
+pub type DefaultHashBuilder = hashbrown::hash_map::DefaultHashBuilder;
+
+/// Re-export default hash builder
+#[cfg(not(feature = "hashbrown"))]
+pub type DefaultHashBuilder = std::collections::hash_map::RandomState;
+
 use std::hash::{BuildHasher, Hash};
 
 mod inner;
@@ -227,11 +243,11 @@ where
     capacity: Option<usize>,
 }
 
-impl Default for Options<(), RandomState> {
+impl Default for Options<(), DefaultHashBuilder> {
     fn default() -> Self {
         Options {
             meta: (),
-            hasher: RandomState::default(),
+            hasher: DefaultHashBuilder::default(),
             capacity: None,
         }
     }
@@ -297,8 +313,8 @@ where
 /// Create an empty eventually consistent map.
 #[cfg_attr(feature = "cargo-clippy", allow(type_complexity))]
 pub fn new<K, V>() -> (
-    ReadHandle<K, V, (), RandomState>,
-    WriteHandle<K, V, (), RandomState>,
+    ReadHandle<K, V, (), DefaultHashBuilder>,
+    WriteHandle<K, V, (), DefaultHashBuilder>,
 )
 where
     K: Eq + Hash + Clone,
@@ -312,8 +328,8 @@ where
 pub fn with_meta<K, V, M>(
     meta: M,
 ) -> (
-    ReadHandle<K, V, M, RandomState>,
-    WriteHandle<K, V, M, RandomState>,
+    ReadHandle<K, V, M, DefaultHashBuilder>,
+    WriteHandle<K, V, M, DefaultHashBuilder>,
 )
 where
     K: Eq + Hash + Clone,

--- a/src/read.rs
+++ b/src/read.rs
@@ -2,6 +2,7 @@ use inner::Inner;
 
 use std::borrow::Borrow;
 use std::cell;
+use std::collections::hash_map::RandomState;
 use std::hash::{BuildHasher, Hash};
 use std::iter::{self, FromIterator};
 use std::marker::PhantomData;
@@ -10,14 +11,12 @@ use std::sync::atomic;
 use std::sync::atomic::AtomicPtr;
 use std::sync::{self, Arc};
 
-use super::DefaultHashBuilder;
-
 /// A handle that may be used to read from the eventually consistent map.
 ///
 /// Note that any changes made to the map will not be made visible until the writer calls
 /// `refresh()`. In other words, all operations performed on a `ReadHandle` will *only* see writes
 /// to the map that preceeded the last call to `refresh()`.
-pub struct ReadHandle<K, V, M = (), S = DefaultHashBuilder>
+pub struct ReadHandle<K, V, M = (), S = RandomState>
 where
     K: Eq + Hash,
     S: BuildHasher,

--- a/src/read.rs
+++ b/src/read.rs
@@ -61,15 +61,7 @@ where
     // tell writer about our epoch tracker
     let epoch = sync::Arc::new(atomic::AtomicUsize::new(0));
 
-    {
-        #[cfg(not(feature = "parking_lot"))]
-        let mut epochs = inner.epochs.lock().unwrap();
-
-        #[cfg(feature = "parking_lot")]
-        let mut epochs = inner.epochs.lock();
-
-        epochs.push(Arc::clone(&epoch));
-    }
+    inner.epochs.lock().unwrap().push(Arc::clone(&epoch));
 
     let store = Box::into_raw(Box::new(inner));
 
@@ -89,13 +81,7 @@ where
 {
     fn register_epoch(&self, epoch: &Arc<atomic::AtomicUsize>) {
         if let Some(epochs) = self.with_handle(|inner| Arc::clone(&inner.epochs)) {
-            #[cfg(not(feature = "parking_lot"))]
-            let mut epochs = epochs.lock().unwrap();
-
-            #[cfg(feature = "parking_lot")]
-            let mut epochs = epochs.lock();
-
-            epochs.push(Arc::clone(epoch));
+            epochs.lock().unwrap().push(Arc::clone(epoch));
         }
     }
 

--- a/src/write.rs
+++ b/src/write.rs
@@ -2,6 +2,7 @@ use super::{Operation, ShallowCopy};
 use inner::{Inner, Values};
 use read::ReadHandle;
 
+use std::collections::hash_map::RandomState;
 use std::hash::{BuildHasher, Hash};
 use std::sync::atomic;
 use std::sync::{Arc, MutexGuard};
@@ -12,8 +13,6 @@ use hashbrown::hash_map::Entry;
 
 #[cfg(not(feature = "hashbrown"))]
 use std::collections::hash_map::Entry;
-
-use super::DefaultHashBuilder;
 
 /// A handle that may be used to modify the eventually consistent map.
 ///
@@ -45,7 +44,7 @@ use super::DefaultHashBuilder;
 /// assert_eq!(r.get_and(&x.0, |rs| rs.len()), Some(1));
 /// assert_eq!(r.get_and(&x.0, |rs| rs.iter().any(|v| v.0 == x.0 && v.1 == x.1)), Some(true));
 /// ```
-pub struct WriteHandle<K, V, M = (), S = DefaultHashBuilder>
+pub struct WriteHandle<K, V, M = (), S = RandomState>
 where
     K: Eq + Hash + Clone,
     S: BuildHasher + Clone,

--- a/src/write.rs
+++ b/src/write.rs
@@ -1,12 +1,25 @@
 use super::{Operation, ShallowCopy};
-use inner::Inner;
+use inner::{Inner, Log};
 use read::ReadHandle;
 
-use std::collections::hash_map::RandomState;
 use std::hash::{BuildHasher, Hash};
 use std::sync::atomic;
-use std::sync::{Arc, MutexGuard};
+use std::sync::Arc;
 use std::{mem, thread};
+
+#[cfg(feature = "parking_lot")]
+use parking_lot::MutexGuard;
+
+#[cfg(not(feature = "parking_lot"))]
+use std::sync::MutexGuard;
+
+#[cfg(feature = "hashbrown")]
+use hashbrown::hash_map::Entry;
+
+#[cfg(not(feature = "hashbrown"))]
+use std::collections::hash_map::Entry;
+
+use super::DefaultHashBuilder;
 
 /// A handle that may be used to modify the eventually consistent map.
 ///
@@ -38,7 +51,7 @@ use std::{mem, thread};
 /// assert_eq!(r.get_and(&x.0, |rs| rs.len()), Some(1));
 /// assert_eq!(r.get_and(&x.0, |rs| rs.iter().any(|v| v.0 == x.0 && v.1 == x.1)), Some(true));
 /// ```
-pub struct WriteHandle<K, V, M = (), S = RandomState>
+pub struct WriteHandle<K, V, M = (), S = DefaultHashBuilder>
 where
     K: Eq + Hash + Clone,
     S: BuildHasher + Clone,
@@ -117,7 +130,13 @@ where
         // destructors of any of the values that are in our map, as they'll all be called when the
         // last read handle goes out of scope.
         for (_, mut vs) in self.w_handle.as_mut().unwrap().data.drain() {
-            for v in vs.drain(..) {
+            #[cfg(not(feature = "smallvec"))]
+            let drain = vs.drain(..);
+
+            #[cfg(feature = "smallvec")]
+            let drain = vs.drain();
+
+            for v in drain {
                 mem::forget(v);
             }
         }
@@ -181,7 +200,13 @@ where
         // only block on pre-existing readers, and they are never waiting to push onto epochs
         // unless they have finished reading.
         let epochs = Arc::clone(&self.w_handle.as_ref().unwrap().epochs);
+
+        #[cfg(not(feature = "parking_lot"))]
         let mut epochs = epochs.lock().unwrap();
+
+        #[cfg(feature = "parking_lot")]
+        let mut epochs = epochs.lock();
+
         self.wait(&mut epochs);
 
         {
@@ -260,7 +285,8 @@ where
         let w_handle = Box::into_raw(w_handle);
 
         // swap in our w_handle, and get r_handle in return
-        let r_handle = self.r_handle
+        let r_handle = self
+            .r_handle
             .inner
             .swap(w_handle, atomic::Ordering::Release);
         let r_handle = unsafe { Box::from_raw(r_handle) };
@@ -341,14 +367,21 @@ where
         self.refresh();
 
         // next, grab the read handle and set it to NULL
-        let r_handle = self.r_handle
+        let r_handle = self
+            .r_handle
             .inner
             .swap(ptr::null_mut(), atomic::Ordering::Release);
         let r_handle = unsafe { Box::from_raw(r_handle) };
 
         // now, wait for all readers to depart
         let epochs = Arc::clone(&self.w_handle.as_ref().unwrap().epochs);
+
+        #[cfg(not(feature = "parking_lot"))]
         let mut epochs = epochs.lock().unwrap();
+
+        #[cfg(feature = "parking_lot")]
+        let mut epochs = epochs.lock();
+
         self.wait(&mut epochs);
 
         // ensure that the subsequent epoch reads aren't re-ordered to before the swap
@@ -458,35 +491,59 @@ where
     fn apply_first(inner: &mut Inner<K, V, M, S>, op: &mut Operation<K, V>) {
         match *op {
             Operation::Replace(ref key, ref mut value) => {
-                let vs = inner.data.entry(key.clone()).or_insert_with(Vec::new);
-                // don't run destructors yet -- still in use by other map
-                for v in vs.drain(..) {
-                    mem::forget(v);
+                let vs = inner.data.entry(key.clone()).or_insert_with(Log::new);
+
+                {
+                    #[cfg(not(feature = "smallvec"))]
+                    let drain = vs.drain(..);
+
+                    #[cfg(feature = "smallvec")]
+                    let drain = vs.drain();
+
+                    // don't run destructors yet -- still in use by other map
+                    for v in drain {
+                        mem::forget(v);
+                    }
                 }
+
                 vs.push(unsafe { value.shallow_copy() });
             }
             Operation::Clear(ref key) => {
-                // don't run destructors yet -- still in use by other map
-                for v in inner
-                    .data
-                    .entry(key.clone())
-                    .or_insert_with(Vec::new)
-                    .drain(..)
-                {
-                    mem::forget(v);
+                match inner.data.entry(key.clone()) {
+                    Entry::Occupied(mut occupied) => {
+                        #[cfg(not(feature = "smallvec"))]
+                        let drain = occupied.get_mut().drain(..);
+
+                        #[cfg(feature = "smallvec")]
+                        let drain = occupied.get_mut().drain();
+
+                        // don't run destructors yet -- still in use by other map
+                        for v in drain {
+                            mem::forget(v);
+                        }
+                    }
+                    Entry::Vacant(vacant) => {
+                        vacant.insert(Log::new());
+                    }
                 }
             }
             Operation::Add(ref key, ref mut value) => {
                 inner
                     .data
                     .entry(key.clone())
-                    .or_insert_with(Vec::new)
+                    .or_insert_with(Log::new)
                     .push(unsafe { value.shallow_copy() });
             }
             Operation::Empty(ref key) => {
                 if let Some(mut vs) = inner.data.remove(key) {
+                    #[cfg(not(feature = "smallvec"))]
+                    let drain = vs.drain(..);
+
+                    #[cfg(feature = "smallvec")]
+                    let drain = vs.drain();
+
                     // don't run destructors yet -- still in use by other map
-                    for v in vs.drain(..) {
+                    for v in drain {
                         mem::forget(v);
                     }
                 }
@@ -507,16 +564,16 @@ where
     fn apply_second(inner: &mut Inner<K, V, M, S>, op: Operation<K, V>) {
         match op {
             Operation::Replace(key, value) => {
-                let v = inner.data.entry(key).or_insert_with(Vec::new);
+                let v = inner.data.entry(key).or_insert_with(Log::new);
                 v.clear();
                 v.push(value);
             }
             Operation::Clear(key) => {
-                let v = inner.data.entry(key).or_insert_with(Vec::new);
+                let v = inner.data.entry(key).or_insert_with(Log::new);
                 v.clear();
             }
             Operation::Add(key, value) => {
-                inner.data.entry(key).or_insert_with(Vec::new).push(value);
+                inner.data.entry(key).or_insert_with(Log::new).push(value);
             }
             Operation::Empty(key) => {
                 inner.data.remove(&key);

--- a/src/write.rs
+++ b/src/write.rs
@@ -1,5 +1,5 @@
 use super::{Operation, ShallowCopy};
-use inner::{Inner, Log};
+use inner::{Inner, Values};
 use read::ReadHandle;
 
 use std::hash::{BuildHasher, Hash};
@@ -491,7 +491,7 @@ where
     fn apply_first(inner: &mut Inner<K, V, M, S>, op: &mut Operation<K, V>) {
         match *op {
             Operation::Replace(ref key, ref mut value) => {
-                let vs = inner.data.entry(key.clone()).or_insert_with(Log::new);
+                let vs = inner.data.entry(key.clone()).or_insert_with(Values::new);
 
                 {
                     #[cfg(not(feature = "smallvec"))]
@@ -523,7 +523,7 @@ where
                         }
                     }
                     Entry::Vacant(vacant) => {
-                        vacant.insert(Log::new());
+                        vacant.insert(Values::new());
                     }
                 }
             }
@@ -531,7 +531,7 @@ where
                 inner
                     .data
                     .entry(key.clone())
-                    .or_insert_with(Log::new)
+                    .or_insert_with(Values::new)
                     .push(unsafe { value.shallow_copy() });
             }
             Operation::Empty(ref key) => {
@@ -564,16 +564,16 @@ where
     fn apply_second(inner: &mut Inner<K, V, M, S>, op: Operation<K, V>) {
         match op {
             Operation::Replace(key, value) => {
-                let v = inner.data.entry(key).or_insert_with(Log::new);
+                let v = inner.data.entry(key).or_insert_with(Values::new);
                 v.clear();
                 v.push(value);
             }
             Operation::Clear(key) => {
-                let v = inner.data.entry(key).or_insert_with(Log::new);
+                let v = inner.data.entry(key).or_insert_with(Values::new);
                 v.clear();
             }
             Operation::Add(key, value) => {
-                inner.data.entry(key).or_insert_with(Log::new).push(value);
+                inner.data.entry(key).or_insert_with(Values::new).push(value);
             }
             Operation::Empty(key) => {
                 inner.data.remove(&key);


### PR DESCRIPTION
This started out as an experiment to see if I could make `evmap` work better with the libraries I'm already using in my projects, but there really isn't a reason not to provide them as features.

The big ones:

[`hashbrown`](https://github.com/Amanieu/hashbrown): Fast and space efficient hash table replacement.
~~[`parking_lot`](https://github.com/Amanieu/parking_lot): Fast and space efficient synchronization primitives.~~

These two are obvious, as they provide generally better and potentially safer functionality (`parking_lot` doesn't poison threads).

Additionally:

[`smallvec`](https://github.com/servo/rust-smallvec): Mixed stack/inline/heap allocated vector.

Although the multi-value map is useful for multiple insertions, if a map never uses that and only ever replaces a single value with `update`, we can cheat by effectively using `[T; 1]` instead, which saves us an extra level of indirection. `smallvec` does grow and allocate if necessary.

Combined, this seems to net about a 50% performance increase on my system, but I need to do a clean run of benchmarks before this is merged. It's certainly better. Plus `hashbrown` is supposed to be more space efficient. 

![read-throughput](https://user-images.githubusercontent.com/4708645/51226669-0d064380-1916-11e9-8516-299d39e0f152.png)

I switched to log10 because the others were getting lost. Also, I have a 16C/32T CPU, so I bumped up the reader counts to compensate. Although for new benchmarks I may try to change the CPU affinity.

Write speeds are about the same.

What are your thoughts?