### PR TITLE
Add more operations and API flexibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,4 +27,4 @@ smallvec = { version = "0.6.7", optional = true }
 [features]
 default = ["hashbrown", "smallvec"]
 nightly_hashbrown = ["hashbrown/nightly"]
-nightly_smallvec = ["smallvec/union"]
+nightly_smallvec = ["smallvec/union", "smallvec/may_dangle", "smallvec/specialization"]

--- a/README.md
+++ b/README.md
@@ -188,10 +188,10 @@ writing.
 ## Small Vector Optimization
 
 By default, the value-set for each key in the map uses the `smallvec` crate to keep a
-maximum of one element stored inline with the map, as opposed to separately allocated
+maximum of one element stored inline with the map, as opposed to separately heap-allocated
 with a plain `Vec`. Operations such as `Fit` and `Replace` will automatically switch
-back to the inline storage if possible. This is ideal for maps that only ever use one
-element per key.
+back to the inline storage if possible. This is ideal for maps that mostly use one
+element per key, as it can improvate memory locality with less indirection.
 
 If this is undesirable, simple set:
 

--- a/README.md
+++ b/README.md
@@ -193,10 +193,20 @@ with a plain `Vec`. Operations such as `Fit` and `Replace` will automatically sw
 back to the inline storage if possible. This is ideal for maps that only ever use one
 element per key.
 
-If this is undesirable, simple set `default-features = false` in the `evmap` dependency entry,
-and `Vec` will always be used internally. Note that this will also opt out
-of the `hashbrown` dependency, which is usually preferred,
-so add that back with `features = ["hashbrown"]`
+If this is undesirable, simple set:
+
+```toml
+default-features = false
+```
+
+in the `evmap` dependency entry, and `Vec` will always be used internally.
+
+Note that this will also opt out of the `hashbrown` dependency, which is usually preferred,
+so add that back with:
+
+```toml
+features = ["hashbrown"]
+```
 
 ## Performance
 

--- a/README.md
+++ b/README.md
@@ -185,6 +185,18 @@ supported. It does, however, also mean that the memory usage of this implementat
 approximately twice of that of a regular `HashMap`, and more if writes rarely refresh after
 writing.
 
+## Small Vector Optimization
+
+By default, the value-set for each key in the map uses the `smallvec` crate to keep a
+maximum of one element stored inline with the map, as opposed to separately allocated
+with a plain `Vec`. Operations such as `Fit` and `Replace` will automatically switch
+back to the inline storage if possible. This is ideal for maps that only ever use one
+element per key.
+
+If this is undesirable, simple set `default-features = false` in the `evmap` dependency entry,
+and `Vec` will always be used internally. Note that this will also opt out
+of the `hashbrown` dependency, which is usually preferred,
+so add that back with `features = ["hashbrown"]`
 
 ## Performance
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,10 +190,20 @@
 //! back to the inline storage if possible. This is ideal for maps that only ever use one
 //! element per key.
 //!
-//! If this is undesirable, simple set `default-features = false` in the `evmap` dependency entry,
-//! and `Vec` will always be used internally. Note that this will also opt out
-//! of the `hashbrown` dependency, which is usually preferred,
-//! so add that back with `features = ["hashbrown"]`
+//! If this is undesirable, simple set:
+//!
+//! ```toml
+//! default-features = false
+//! ```
+//!
+//! in the `evmap` dependency entry, and `Vec` will always be used internally.
+//!
+//! Note that this will also opt out of the `hashbrown` dependency, which is usually preferred,
+//! so add that back with:
+//!
+//! ```toml
+//! features = ["hashbrown"]
+//! ```
 //!
 #![deny(missing_docs)]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -255,6 +255,12 @@ pub enum Operation<K, V> {
     Truncate(K, usize),
     /// Reverses the value-set for this key.
     Reverse(K),
+    /// Reserves capacity for some number of additional elements in a value-set,
+    /// or creates an empty value-set for this key with the given capacity if
+    /// it doesn't already exist.
+    ///
+    /// This can improve performance by pre-allocating space for large value-sets.
+    Reserve(K, usize),
 }
 
 mod write;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,6 +182,19 @@
 //! approximately twice of that of a regular `HashMap`, and more if writes rarely refresh after
 //! writing.
 //!
+//! # Small Vector Optimization
+//!
+//! By default, the value-set for each key in the map uses the `smallvec` crate to keep a
+//! maximum of one element stored inline with the map, as opposed to separately allocated
+//! with a plain `Vec`. Operations such as `Fit` and `Replace` will automatically switch
+//! back to the inline storage if possible. This is ideal for maps that only ever use one
+//! element per key.
+//!
+//! If this is undesirable, simple set `default-features = false` in the `evmap` dependency entry,
+//! and `Vec` will always be used internally. Note that this will also opt out
+//! of the `hashbrown` dependency, which is usually preferred,
+//! so add that back with `features = ["hashbrown"]`
+//!
 #![deny(missing_docs)]
 
 #[cfg(feature = "hashbrown")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,7 +225,9 @@ impl<V> Eq for Predicate<V> {}
 
 impl<V> fmt::Debug for Predicate<V> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Predicate({:p})", &*self.0 as *const _)
+        f.debug_tuple("Predicate")
+            .field(&format_args!("{:p}", &*self.0 as *const _))
+            .finish()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,10 +185,10 @@
 //! # Small Vector Optimization
 //!
 //! By default, the value-set for each key in the map uses the `smallvec` crate to keep a
-//! maximum of one element stored inline with the map, as opposed to separately allocated
+//! maximum of one element stored inline with the map, as opposed to separately heap-allocated
 //! with a plain `Vec`. Operations such as `Fit` and `Replace` will automatically switch
-//! back to the inline storage if possible. This is ideal for maps that only ever use one
-//! element per key.
+//! back to the inline storage if possible. This is ideal for maps that mostly use one
+//! element per key, as it can improvate memory locality with less indirection.
 //!
 //! If this is undesirable, simple set:
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -251,10 +251,6 @@ pub enum Operation<K, V> {
     ///
     /// If no key is given, all value-sets will shrink to fit.
     Fit(Option<K>),
-    /// Truncates the value-set for this key to the given length.
-    Truncate(K, usize),
-    /// Reverses the value-set for this key.
-    Reverse(K),
     /// Reserves capacity for some number of additional elements in a value-set,
     /// or creates an empty value-set for this key with the given capacity if
     /// it doesn't already exist.

--- a/src/read.rs
+++ b/src/read.rs
@@ -1,4 +1,4 @@
-use inner::Inner;
+use inner::{Inner, Values};
 
 use std::borrow::Borrow;
 use std::cell;
@@ -152,6 +152,23 @@ where
         self.with_handle(|inner| inner.meta.clone())
     }
 
+    /// Internal version of `get_and`
+    fn get_raw<Q: ?Sized, F, T>(&self, key: &Q, then: F) -> Option<T>
+    where
+        F: FnOnce(&Values<V>) -> T,
+        K: Borrow<Q>,
+        Q: Hash + Eq,
+    {
+        self.with_handle(move |inner| {
+            if !inner.is_ready() {
+                None
+            } else {
+                inner.data.get(key).map(then)
+            }
+        })
+        .unwrap_or(None)
+    }
+
     /// Applies a function to the values corresponding to the key, and returns the result.
     ///
     /// The key may be any borrowed form of the map's key type, but `Hash` and `Eq` on the borrowed
@@ -162,20 +179,15 @@ where
     ///
     /// If no values exist for the given key, no refresh has happened, or the map has been
     /// destroyed, `then` will not be called, and `None` will be returned.
+    #[inline]
     pub fn get_and<Q: ?Sized, F, T>(&self, key: &Q, then: F) -> Option<T>
     where
         F: FnOnce(&[V]) -> T,
         K: Borrow<Q>,
         Q: Hash + Eq,
     {
-        self.with_handle(move |inner| {
-            if !inner.is_ready() {
-                None
-            } else {
-                inner.data.get(key).map(move |v| then(&**v))
-            }
-        })
-        .unwrap_or(None)
+        // call `borrow` here to monomorphize `get_raw` fewer times
+        self.get_raw(key.borrow(), |values| then(&**values))
     }
 
     /// Applies a function to the values corresponding to the key, and returns the result alongside
@@ -253,5 +265,31 @@ where
             Collector::from_iter(inner.data.iter().map(|(k, vs)| f(k, &vs[..])))
         })
         .unwrap_or_else(|| Collector::from_iter(iter::empty()))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::new;
+
+    #[test]
+    fn reserve_and_fit() {
+        let (r, mut w) = new();
+
+        // 64 is the second power of two higher than 17,
+        // so it should at least shrink the vector to less than
+        // or equal to the next highest power of 2 after 17
+        w.reserve(0, 64).refresh();
+
+        r.get_raw(&0, |vs| assert_eq!(vs.capacity(), 64)).unwrap();
+
+        // 1 + 2^4, so it's a tiny bit more than a power of two
+        for i in 0..17 {
+            w.insert(0, i);
+        }
+
+        w.fit_all().refresh();
+
+        r.get_raw(&0, |vs| assert!(vs.capacity() < 64)).unwrap();
     }
 }

--- a/src/read.rs
+++ b/src/read.rs
@@ -272,24 +272,27 @@ where
 mod test {
     use crate::new;
 
+    // the idea of this test is to allocate 64 elements, and only use 17. The vector will
+    // probably try to fit either exactly the length, to the next highest power of 2 from
+    // the length, or something else entirely, E.g. 17, 32, etc.,
+    // but it should always end up being smaller than the original 64 elements reserved.
     #[test]
     fn reserve_and_fit() {
+        const MIN: usize = (1 << 4) + 1;
+        const MAX: usize = (1 << 6);
+
         let (r, mut w) = new();
 
-        // 64 is the second power of two higher than 17,
-        // so it should at least shrink the vector to less than
-        // or equal to the next highest power of 2 after 17
-        w.reserve(0, 64).refresh();
+        w.reserve(0, MAX).refresh();
 
-        r.get_raw(&0, |vs| assert_eq!(vs.capacity(), 64)).unwrap();
+        r.get_raw(&0, |vs| assert_eq!(vs.capacity(), MAX)).unwrap();
 
-        // 1 + 2^4, so it's a tiny bit more than a power of two
-        for i in 0..17 {
+        for i in 0..MIN {
             w.insert(0, i);
         }
 
         w.fit_all().refresh();
 
-        r.get_raw(&0, |vs| assert!(vs.capacity() < 64)).unwrap();
+        r.get_raw(&0, |vs| assert!(vs.capacity() < MAX)).unwrap();
     }
 }

--- a/src/write.rs
+++ b/src/write.rs
@@ -498,11 +498,16 @@ where
     /// Shrinks a value-set to it's minimum necessary size, freeing memory
     /// and potentially improving cache locality if the `smallvec` feature is used.
     ///
-    /// If no key is given, <b>ALL</b> value-sets will shrink to fit.
-    ///
     /// The optimized value-set will only be visible to readers after the next call to `refresh()`
-    pub fn fit(&mut self, k: Option<K>) -> &mut Self {
-        self.add_op(Operation::Fit(k))
+    pub fn fit(&mut self, k: K) -> &mut Self {
+        self.add_op(Operation::Fit(Some(k)))
+    }
+
+    /// Like [`WriteHandle::fit`](#method.fit), but shrinks <b>all</b> value-sets in the map.
+    ///
+    /// The optimized value-sets will only be visible to readers after the next call to `refresh()`
+    pub fn fit_all(&mut self) -> &mut Self {
+        self.add_op(Operation::Fit(None))
     }
 
     /// Reserves capacity for some number of additional elements in a value-set,

--- a/src/write.rs
+++ b/src/write.rs
@@ -505,20 +505,6 @@ where
         self.add_op(Operation::Fit(k))
     }
 
-    /// Truncates the value-set for this key to the given length.
-    ///
-    /// The truncated value-set will only be visible to readers after the next call to `refresh()`
-    pub fn truncate(&mut self, k: K, len: usize) -> &mut Self {
-        self.add_op(Operation::Truncate(k, len))
-    }
-
-    /// Reverses the value-set for this key.
-    ///
-    /// The reversed value-set will only be visible to readers after the next call to `refresh()`
-    pub fn reverse(&mut self, k: K) -> &mut Self {
-        self.add_op(Operation::Reverse(k))
-    }
-
     /// Reserves capacity for some number of additional elements in a value-set,
     /// or creates an empty value-set for this key with the given capacity if
     /// it doesn't already exist.
@@ -636,19 +622,6 @@ where
                     }
                 }
             },
-            Operation::Truncate(ref key, len) => {
-                if let Some(e) = inner.data.get_mut(key) {
-                    unsafe {
-                        // truncate vector without dropping values
-                        e.set_len(len);
-                    }
-                }
-            }
-            Operation::Reverse(ref key) => {
-                if let Some(e) = inner.data.get_mut(key) {
-                    e.reverse();
-                }
-            }
             Operation::Reserve(ref key, additional) => {
                 inner
                     .data
@@ -706,16 +679,6 @@ where
                     }
                 }
             },
-            Operation::Truncate(key, len) => {
-                if let Some(e) = inner.data.get_mut(&key) {
-                    e.truncate(len);
-                }
-            }
-            Operation::Reverse(key) => {
-                if let Some(e) = inner.data.get_mut(&key) {
-                    e.reverse();
-                }
-            }
             Operation::Reserve(key, additional) => {
                 inner
                     .data

--- a/src/write.rs
+++ b/src/write.rs
@@ -501,9 +501,9 @@ where
     /// The remaining value-set will only be visible to readers after the next call to `refresh()`
     pub fn retain<F>(&mut self, k: K, f: F) -> &mut Self
     where
-        F: Fn(&V) -> bool + 'static + Send,
+        F: Fn(&V) -> bool + 'static + Send + Sync,
     {
-        self.add_op(Operation::Retain(k, Predicate(Box::new(f))))
+        self.add_op(Operation::Retain(k, Predicate(Arc::new(f))))
     }
 
     /// Shrinks a value-set to it's minimum necessary size, freeing memory

--- a/src/write.rs
+++ b/src/write.rs
@@ -603,11 +603,13 @@ where
             Operation::Retain(ref key, ref predicate) => {
                 if let Some(e) = inner.data.get_mut(key) {
                     let mut del = 0;
-
                     let len = e.len();
 
-                    // "bubble up" the values we wish to remove,
-                    // so they can be truncated.
+                    // "bubble up" the values we wish to remove, so they can be truncated.
+                    //
+                    // See https://github.com/servo/rust-smallvec/blob/a775b5f74cce0d3c7218608fd9f6fd721bb0f461/lib.rs#L881-L897
+                    // for SmallVec's implementation of `retain`, the only difference being that we
+                    // cannot drop values here, so they are truncated with `set_len`
                     for i in 0..len {
                         if !predicate.eval(unsafe { e.get_unchecked(i) }) {
                             del += 1;

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -387,3 +387,30 @@ fn foreach() {
         _ => unreachable!(),
     });
 }
+
+#[test]
+fn retain() {
+    // do same operations on a plain vector
+    // to verify retain implementation
+    let mut v = Vec::new();
+    let (r, mut w) = evmap::new();
+
+    for i in 0..50 {
+        w.insert(0, i);
+        v.push(i);
+    }
+
+    w.retain(0, |num| num % 2 == 0).refresh();
+    v.retain(|num| num % 2 == 0);
+
+    r.get_and(&0, |nums| {
+        assert_eq!(nums.len(), 25);
+        assert_eq!(nums.len(), v.len());
+
+        for (a, b) in nums.iter().zip(&v) {
+            assert_eq!(a, b);
+            assert_eq!(a % 2, 0);
+        }
+    })
+    .unwrap();
+}

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -400,17 +400,12 @@ fn retain() {
         v.push(i);
     }
 
-    w.retain(0, |num| num % 2 == 0).refresh();
-    v.retain(|num| num % 2 == 0);
+    fn is_even(num: &i32) -> bool {
+        num % 2 == 0
+    }
 
-    r.get_and(&0, |nums| {
-        assert_eq!(nums.len(), 25);
-        assert_eq!(nums.len(), v.len());
+    w.retain(0, is_even).refresh();
+    v.retain(is_even);
 
-        for (a, b) in nums.iter().zip(&v) {
-            assert_eq!(a, b);
-            assert_eq!(a % 2, 0);
-        }
-    })
-    .unwrap();
+    r.get_and(&0, |nums| assert_eq!(v, nums)).unwrap();
 }


### PR DESCRIPTION
## Rationale 

For the application I intend to use `evmap` in, I keep an operational log of values with their own timestamps. `evmap` is ideal for this, as an operational log is built-in and natural. 

However, after a while, it becomes necessary to prune older versions of these values, and with the recently added `smallvec` feature it would be useful to occasionally renormalize the values to fit within the inline vector.

## Added Operations

To this end, I propose three new operations (or more if suggested):

* `Retain`
* `Fit`
* `Reserve`

`Retain` takes a closure predicate and converts it to a `'static` thread-safe trait object (`Box<Fn + Send>`), which can be used later to remove items from the value-set that do not satisfy the predicate. It works almost exactly like [`Vec::retain`](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.retain)

`Fit` is simply short for `shrink_to_fit`, which for `smallvec` will move the item(s) back to the inline storage if possible and deallocate the heap storage. This is provided per-key or for the entire map.

`Reserve` pre-allocates space for a value-set, both in the hashmap and for the value-set elements themselves.

## Additional Thoughts

It would be nice to have a way to operate on the entire underlying map from user code, safely. One example would be an alternative `Retain` implementation that uses `rayon` to iterate over the entire map in parallel, or similar operations in parallel. Unfortunately, as of now I'm not sure how that could be done.