### PR TITLE
Remove defunct test for non implementation of sync

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,9 @@ indexmap = { version = "1.1.0", optional = true }
 smallvec = { version = "1.0.0", optional = true }
 bytes = { version = "0.5", optional = true }
 
+[dev-dependencies]
+static_assertions = "1.1.0"
+
 [features]
 default = ["smallvec"]
 indexed = ["indexmap"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,9 +27,6 @@ indexmap = { version = "1.1.0", optional = true }
 smallvec = { version = "1.0.0", optional = true }
 bytes = { version = "0.5", optional = true }
 
-[dev-dependencies]
-static_assertions = "1.1.0"
-
 [features]
 default = ["smallvec"]
 indexed = ["indexmap"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -431,3 +431,10 @@ where
         .with_meta(meta)
         .construct()
 }
+
+
+#[test]
+fn is_not_sync() {
+    extern crate static_assertions as sa;
+    sa::assert_not_impl_all!(ReadHandle<(), ()>: Send, Sync);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -431,15 +431,3 @@ where
         .with_meta(meta)
         .construct()
 }
-
-// test that ReadHandle isn't Sync
-// waiting on https://github.com/rust-lang/rust/issues/17606
-//#[test]
-//fn is_not_sync() {
-//    use std::sync;
-//    use std::thread;
-//    let (r, mut w) = new();
-//    w.insert(true, false);
-//    let x = sync::Arc::new(r);
-//    thread::spawn(move || { drop(x); });
-//}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,9 +164,9 @@
 //! }
 //! ```
 //!
-//! `ReadHandle` is not `Sync` as it is not safe to share a single instance
-//! amongst threads. A fresh `ReadHandle` needs to be created for each thread
-//! either by cloning a `ReadHandle` or from a `ReadHandleFactory`.
+//! ReadHandle is not Sync as it is not safe to share a single instance
+//! amongst threads. A fresh ReadHandle needs to be created for each thread
+//! either by cloning a ReadHandle or from a ReadHandleFactory.
 //!
 //! The reason for this is that each ReadHandle assumes that only one
 //! thread operates on it at a time. For details, see the implementation
@@ -184,7 +184,7 @@
 //! is_sync::<ReadHandle<u64, u64>>()
 //!```
 //!
-//! ReadHandle is Send though, since in order to send a ReadHandle, there must
+//! ReadHandle **is** Send though, since in order to send a ReadHandle, there must
 //! be no references to it, so no thread is operating on it.
 //!
 //!```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,13 +164,13 @@
 //! }
 //! ```
 //!
-//! ReadHandle is not Sync as it is not safe to share a single instance
-//! amongst threads. A fresh ReadHandle needs to be created for each thread
-//! either by cloning a ReadHandle or from a ReadHandleFactory.
+//! `ReadHandle` is not `Sync` as it is not safe to share a single instance
+//! amongst threads. A fresh `ReadHandle` needs to be created for each thread
+//! either by cloning a `ReadHandle` or from a `ReadHandleFactory`.
 //!
-//! The reason for this is that each ReadHandle assumes that only one
+//! The reason for this is that each `ReadHandle` assumes that only one
 //! thread operates on it at a time. For details, see the implementation
-//! comments on ReadHandle.
+//! comments on `ReadHandle`.
 //!
 //!```compile_fail
 //! use evmap::ReadHandle;
@@ -184,8 +184,8 @@
 //! is_sync::<ReadHandle<u64, u64>>()
 //!```
 //!
-//! ReadHandle **is** Send though, since in order to send a ReadHandle, there must
-//! be no references to it, so no thread is operating on it.
+//! `ReadHandle` **is** `Send` though, since in order to send a `ReadHandle`,
+//! there must be no references to it, so no thread is operating on it.
 //!
 //!```
 //! use evmap::ReadHandle;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,6 +168,10 @@
 //! amongst threads. A fresh `ReadHandle` needs to be created for each thread
 //! either by cloning a `ReadHandle` or from a `ReadHandleFactory`.
 //!
+//! The reason for this is that each ReadHandle assumes that only one
+//! thread operates on it at a time. For details, see the implementation
+//! comments on ReadHandle.
+//!
 //!```compile_fail
 //! use evmap::ReadHandle;
 //!
@@ -180,7 +184,8 @@
 //! is_sync::<ReadHandle<u64, u64>>()
 //!```
 //!
-//! `ReadHandle` is `Send` so it is safe to send to other threads
+//! ReadHandle is Send though, since in order to send a ReadHandle, there must
+//! be no references to it, so no thread is operating on it.
 //!
 //!```
 //! use evmap::ReadHandle;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,6 +164,26 @@
 //! }
 //! ```
 //!
+//!```compile_fail
+//! use evmap::ReadHandle;
+//!
+//! fn is_sync<T: Sync>() {
+//!   // dummy function just used for its parameterized type bound
+//! }
+//!
+//! is_sync::<ReadHandle<u64, u64>>()
+//!```
+//!
+//!```
+//! use evmap::ReadHandle;
+//!
+//! fn is_send<T: Send>() {
+//!   // dummy function just used for its parameterized type bound
+//! }
+//!
+//! is_send::<ReadHandle<u64, u64>>()
+//!```
+//!
 //! # Implementation
 //!
 //! Under the hood, the map is implemented using two regular `HashMap`s, an operational log,
@@ -430,10 +450,4 @@ where
         .with_hasher(hasher)
         .with_meta(meta)
         .construct()
-}
-
-#[test]
-fn is_not_sync() {
-    extern crate static_assertions as sa;
-    sa::assert_not_impl_all!(ReadHandle<(), ()>: Send, Sync);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -432,7 +432,6 @@ where
         .construct()
 }
 
-
 #[test]
 fn is_not_sync() {
     extern crate static_assertions as sa;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,6 +164,10 @@
 //! }
 //! ```
 //!
+//! `ReadHandle` is not `Sync` as it is not safe to share a single instance
+//! amongst threads. A fresh `ReadHandle` needs to be created for each thread
+//! either by cloning a `ReadHandle` or from a `ReadHandleFactory`.
+//!
 //!```compile_fail
 //! use evmap::ReadHandle;
 //!
@@ -171,8 +175,12 @@
 //!   // dummy function just used for its parameterized type bound
 //! }
 //!
+//! // the line below will not compile as ReadHandle does not implement Sync
+//!
 //! is_sync::<ReadHandle<u64, u64>>()
 //!```
+//!
+//! `ReadHandle` is `Send` so it is safe to send to other threads
 //!
 //!```
 //! use evmap::ReadHandle;
@@ -183,6 +191,8 @@
 //!
 //! is_send::<ReadHandle<u64, u64>>()
 //!```
+//!
+//! For further explanation of `Sync` and `Send` [here](https://doc.rust-lang.org/nomicon/send-and-sync.html)
 //!
 //! # Implementation
 //!


### PR DESCRIPTION
Hey I was looking through the implementation of this for a separate project and noticed this test which seems to be no longer necessary. I hope this is helpful!

The rust doc issue is now resolved with https://github.com/rust-lang/rust/pull/47833

The documentation in cargo appears to reflect this as Sync is marked !Sync
https://docs.rs/evmap/4.1.1/evmap/struct.ReadHandle.html#impl-Sync