### PR TITLE
Bump bytes dependency to 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ maintenance = { status = "passively-maintained" }
 [dependencies]
 indexmap = { version = "1.1.0", optional = true }
 smallvec = { version = "1.0.0", optional = true }
-bytes = { version = "0.4.12", optional = true }
+bytes = { version = "0.5.4", optional = true }
 
 [features]
 default = ["smallvec"]


### PR DESCRIPTION
This seems to work as-is and helps interop with other crates in the ecosystem that have upgraded.

Thanks!