### PR TITLE
Mark Operation enum as non_exhaustive

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,7 @@
 jobs:
  - template: default.yml@templates
    parameters:
-     minrust: 1.36.0
+     minrust: 1.40.0
      codecov_token: $(CODECOV_TOKEN_SECRET)
 
 resources:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -241,12 +241,8 @@ impl<V> fmt::Debug for Predicate<V> {
 }
 
 /// A pending map operation.
-///
-/// Note that this enum should be considered
-/// [non-exhaustive](https://github.com/rust-lang/rust/issues/44109).
+#[non_exhaustive]
 #[derive(PartialEq, Eq, Debug)]
-// TODO: #[non_exhaustive]
-// https://github.com/rust-lang/rust/issues/44109
 pub enum Operation<K, V> {
     /// Replace the set of entries for this key with this value.
     Replace(K, V),
@@ -278,11 +274,6 @@ pub enum Operation<K, V> {
     ///
     /// This can improve performance by pre-allocating space for large value-sets.
     Reserve(K, usize),
-    // Since we have a feature that adds an enum variant, features are only additive (as they need
-    // to be) if users never try to exhaustively match on this enum. Once rust-lang/rust#44109
-    // lands, we'll have a more standard way to do this, but for now we rely on this trick:
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 mod write;

--- a/src/write.rs
+++ b/src/write.rs
@@ -640,7 +640,6 @@ where
                     entry.insert(Values::with_capacity(additional));
                 }
             },
-            Operation::__Nonexhaustive => unreachable!(),
         }
     }
 
@@ -718,7 +717,6 @@ where
                     entry.insert(Values::with_capacity(additional));
                 }
             },
-            Operation::__Nonexhaustive => unreachable!(),
         }
     }
 }


### PR DESCRIPTION
Since rust-lang/rust#44109 has landed, remove the hackery around non-exhaustive matching
and use the attribute #[non_exhaustive] instead.