### PR TITLE
Move to a guard-based read API

### DIFF
--- a/src/inner.rs
+++ b/src/inner.rs
@@ -2,9 +2,9 @@ use std::fmt;
 use std::hash::{BuildHasher, Hash};
 
 #[cfg(feature = "indexed")]
-use indexmap::IndexMap as MapImpl;
+pub(crate) use indexmap::IndexMap as MapImpl;
 #[cfg(not(feature = "indexed"))]
-use std::collections::HashMap as MapImpl;
+pub(crate) use std::collections::HashMap as MapImpl;
 
 #[cfg(not(feature = "smallvec"))]
 pub(crate) type Values<T> = Vec<T>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,46 +49,45 @@
 //! book_reviews_w.refresh();
 //! assert_eq!(book_reviews_r.len(), 4);
 //! // reads will now return Some() because the map has been initialized
-//! assert_eq!(book_reviews_r.get_and("Grimms' Fairy Tales", |rs| rs.len()), Some(1));
+//! assert_eq!(book_reviews_r.get("Grimms' Fairy Tales").map(|rs| rs.len()), Some(1));
 //!
 //! // remember, this is a multi-value map, so we can have many reviews
 //! book_reviews_w.insert("Grimms' Fairy Tales",               "Eh, the title seemed weird.");
 //! book_reviews_w.insert("Pride and Prejudice",               "Too many words.");
 //!
 //! // but again, new writes are not yet visible
-//! assert_eq!(book_reviews_r.get_and("Grimms' Fairy Tales", |rs| rs.len()), Some(1));
+//! assert_eq!(book_reviews_r.get("Grimms' Fairy Tales").map(|rs| rs.len()), Some(1));
 //!
 //! // we need to refresh first
 //! book_reviews_w.refresh();
-//! assert_eq!(book_reviews_r.get_and("Grimms' Fairy Tales", |rs| rs.len()), Some(2));
+//! assert_eq!(book_reviews_r.get("Grimms' Fairy Tales").map(|rs| rs.len()), Some(2));
 //!
 //! // oops, this review has a lot of spelling mistakes, let's delete it.
 //! // empty deletes *all* reviews (though in this case, just one)
 //! book_reviews_w.empty("The Adventures of Sherlock Holmes");
 //! // but again, it's not visible to readers until we refresh
-//! assert_eq!(book_reviews_r.get_and("The Adventures of Sherlock Holmes", |rs| rs.len()), Some(1));
+//! assert_eq!(book_reviews_r.get("The Adventures of Sherlock Holmes").map(|rs| rs.len()), Some(1));
 //! book_reviews_w.refresh();
-//! assert_eq!(book_reviews_r.get_and("The Adventures of Sherlock Holmes", |rs| rs.len()), None);
+//! assert_eq!(book_reviews_r.get("The Adventures of Sherlock Holmes").map(|rs| rs.len()), None);
 //!
 //! // look up the values associated with some keys.
 //! let to_find = ["Pride and Prejudice", "Alice's Adventure in Wonderland"];
 //! for book in &to_find {
-//!     let reviewed = book_reviews_r.get_and(book, |reviews| {
-//!         for review in reviews {
+//!     if let Some(reviews) = book_reviews_r.get(book) {
+//!         for review in &*reviews {
 //!             println!("{}: {}", book, review);
 //!         }
-//!     });
-//!     if reviewed.is_none() {
+//!     } else {
 //!         println!("{} is unreviewed.", book);
 //!     }
 //! }
 //!
 //! // iterate over everything.
-//! book_reviews_r.for_each(|book, reviews| {
+//! for (book, reviews) in &book_reviews_r.read() {
 //!     for review in reviews {
 //!         println!("{}: \"{}\"", book, review);
 //!     }
-//! });
+//! }
 //! ```
 //!
 //! Reads from multiple threads are possible by cloning the `ReadHandle`.
@@ -280,7 +279,7 @@ mod write;
 pub use crate::write::WriteHandle;
 
 mod read;
-pub use crate::read::{ReadHandle, ReadHandleFactory};
+pub use crate::read::{MapReadRef, ReadGuard, ReadGuardIter, ReadHandle, ReadHandleFactory};
 
 pub mod shallow_copy;
 pub use crate::shallow_copy::ShallowCopy;

--- a/src/read/factory.rs
+++ b/src/read/factory.rs
@@ -1,0 +1,61 @@
+use super::ReadHandle;
+use crate::inner::Inner;
+
+use std::collections::hash_map::RandomState;
+use std::hash::{BuildHasher, Hash};
+use std::sync::atomic::AtomicPtr;
+use std::{fmt, sync};
+
+/// A type that is both `Sync` and `Send` and lets you produce new [`ReadHandle`] instances.
+///
+/// This serves as a handy way to distribute read handles across many threads without requiring
+/// additional external locking to synchronize access to the non-`Sync` `ReadHandle` type. Note
+/// that this _internally_ takes a lock whenever you call [`ReadHandleFactory::handle`], so
+/// you should not expect producing new handles rapidly to scale well.
+pub struct ReadHandleFactory<K, V, M = (), S = RandomState>
+where
+    K: Eq + Hash,
+    S: BuildHasher,
+{
+    pub(super) inner: sync::Arc<AtomicPtr<Inner<K, V, M, S>>>,
+    pub(super) epochs: crate::Epochs,
+}
+
+impl<K, V, M, S> fmt::Debug for ReadHandleFactory<K, V, M, S>
+where
+    K: Eq + Hash,
+    S: BuildHasher,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ReadHandleFactory")
+            .field("epochs", &self.epochs)
+            .finish()
+    }
+}
+
+impl<K, V, M, S> Clone for ReadHandleFactory<K, V, M, S>
+where
+    K: Eq + Hash,
+    S: BuildHasher,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: sync::Arc::clone(&self.inner),
+            epochs: sync::Arc::clone(&self.epochs),
+        }
+    }
+}
+
+impl<K, V, M, S> ReadHandleFactory<K, V, M, S>
+where
+    K: Eq + Hash,
+    S: BuildHasher,
+{
+    /// Produce a new [`ReadHandle`] to the same map as this factory was originally produced from.
+    pub fn handle(&self) -> ReadHandle<K, V, M, S> {
+        ReadHandle::new(
+            sync::Arc::clone(&self.inner),
+            sync::Arc::clone(&self.epochs),
+        )
+    }
+}

--- a/src/read/guard.rs
+++ b/src/read/guard.rs
@@ -1,0 +1,66 @@
+use std::mem;
+use std::sync;
+use std::sync::atomic;
+
+/// A guard wrapping a live reference into an evmap.
+///
+/// As long as this guard lives, the map being read cannot change, and if a writer attempts to
+/// call [`WriteHandle::refresh`], that call will block until this guard is dropped.
+#[derive(Debug)]
+pub struct ReadGuard<'rh, T: ?Sized> {
+    // NOTE: _technically_ this is more like &'self.
+    // the reference is valid until the guard is dropped.
+    pub(super) t: &'rh T,
+    pub(super) epoch: usize,
+    pub(super) handle: &'rh sync::atomic::AtomicUsize,
+}
+
+impl<'rh, T: ?Sized> ReadGuard<'rh, T> {
+    pub(super) fn map_ref<F, U: ?Sized>(self, f: F) -> ReadGuard<'rh, U>
+    where
+        F: for<'a> FnOnce(&'a T) -> &'a U,
+    {
+        let rg = ReadGuard {
+            t: f(self.t),
+            epoch: self.epoch,
+            handle: self.handle,
+        };
+        mem::forget(self);
+        rg
+    }
+
+    pub(super) fn map_opt<F, U: ?Sized>(self, f: F) -> Option<ReadGuard<'rh, U>>
+    where
+        F: for<'a> FnOnce(&'a T) -> Option<&'a U>,
+    {
+        let rg = Some(ReadGuard {
+            t: f(self.t)?,
+            epoch: self.epoch,
+            handle: self.handle,
+        });
+        mem::forget(self);
+        rg
+    }
+}
+
+impl<'rh, T: ?Sized> AsRef<T> for ReadGuard<'rh, T> {
+    fn as_ref(&self) -> &T {
+        self.t
+    }
+}
+
+impl<'rh, T: ?Sized> std::ops::Deref for ReadGuard<'rh, T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        self.t
+    }
+}
+
+impl<'rh, T: ?Sized> Drop for ReadGuard<'rh, T> {
+    fn drop(&mut self) {
+        self.handle.store(
+            (self.epoch + 1) | 1usize << (mem::size_of::<usize>() * 8 - 1),
+            atomic::Ordering::Release,
+        );
+    }
+}

--- a/src/read/read_ref.rs
+++ b/src/read/read_ref.rs
@@ -1,0 +1,151 @@
+use super::ReadGuard;
+use crate::inner::Inner;
+
+use std::borrow::Borrow;
+use std::hash::{BuildHasher, Hash};
+
+/// A live reference into the read half of an evmap.
+///
+/// As long as this lives, the map being read cannot change, and if a writer attempts to
+/// call [`WriteHandle::refresh`], that call will block until this is dropped.
+///
+/// Since the map remains immutable while this lives, the methods on this type all give you
+/// unguarded references to types contained in the map.
+#[derive(Debug)]
+pub struct MapReadRef<'rh, K, V, M, S>
+where
+    K: Hash + Eq,
+    S: BuildHasher,
+{
+    pub(super) guard: Option<ReadGuard<'rh, Inner<K, V, M, S>>>,
+}
+
+impl<'rh, K, V, M, S> MapReadRef<'rh, K, V, M, S>
+where
+    K: Hash + Eq,
+    S: BuildHasher,
+{
+    /// Iterate over all key + valuesets in the map.
+    ///
+    /// Be careful with this function! While the iteration is ongoing, any writer that tries to
+    /// refresh will block waiting on this reader to finish.
+    pub fn iter<'a>(&'a self) -> ReadGuardIter<'a, K, V, S> {
+        ReadGuardIter {
+            iter: self.guard.as_ref().map(|rg| rg.data.iter()),
+        }
+    }
+
+    /// Returns the number of non-empty keys present in the map.
+    pub fn len(&self) -> usize {
+        self.guard
+            .as_ref()
+            .map(|inner| inner.data.len())
+            .unwrap_or(0)
+    }
+
+    /// Returns true if the map contains no elements.
+    pub fn is_empty(&self) -> bool {
+        self.guard
+            .as_ref()
+            .map(|inner| inner.data.is_empty())
+            .unwrap_or(true)
+    }
+
+    /// Get the current meta value.
+    pub fn meta(&self) -> Option<&M> {
+        self.guard.as_ref().map(|inner| &inner.meta)
+    }
+
+    /// Returns a reference to the value-set corresponding to the key.
+    ///
+    /// The key may be any borrowed form of the map's key type, but `Hash` and `Eq` on the borrowed
+    /// form *must* match those for the key type.
+    ///
+    /// Note that not all writes will be included with this read -- only those that have been
+    /// refreshed by the writer. If no refresh has happened, or the map has been destroyed, this
+    /// function returns `None`.
+    pub fn get<'a, Q: ?Sized>(&'a self, key: &'_ Q) -> Option<&'a [V]>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq,
+    {
+        let inner = self.guard.as_ref()?;
+        if !inner.is_ready() {
+            return None;
+        }
+        inner.data.get(key).map(|v| &v[..])
+    }
+
+    /// Returns true if the writer has destroyed this map.
+    ///
+    /// See [`WriteHandle::destroy`].
+    pub fn is_destroyed(&self) -> bool {
+        self.guard.is_none()
+    }
+
+    /// Returns true if the map contains any values for the specified key.
+    ///
+    /// The key may be any borrowed form of the map's key type, but `Hash` and `Eq` on the borrowed
+    /// form *must* match those for the key type.
+    pub fn contains_key<Q: ?Sized>(&self, key: &Q) -> bool
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq,
+    {
+        let inner = self.guard.as_ref();
+        match inner {
+            None => false,
+            Some(ref inner) if !inner.is_ready() => false,
+            Some(ref inner) => inner.data.contains_key(key),
+        }
+    }
+}
+
+impl<'rh, K, Q, V, M, S> std::ops::Index<&'_ Q> for MapReadRef<'rh, K, V, M, S>
+where
+    K: Eq + Hash + Borrow<Q>,
+    Q: Eq + Hash + ?Sized,
+    S: BuildHasher,
+{
+    type Output = [V];
+    fn index(&self, key: &Q) -> &Self::Output {
+        self.get(key).unwrap()
+    }
+}
+
+impl<'rg, 'rh, K, V, M, S> IntoIterator for &'rg MapReadRef<'rh, K, V, M, S>
+where
+    K: Eq + Hash,
+    S: BuildHasher,
+{
+    type Item = (&'rg K, &'rg [V]);
+    type IntoIter = ReadGuardIter<'rg, K, V, S>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+/// An [`Iterator`] over keys and value-sets in the evmap.
+#[derive(Debug)]
+pub struct ReadGuardIter<'rg, K, V, S>
+where
+    K: Eq + Hash,
+    S: BuildHasher,
+{
+    iter: Option<
+        <&'rg crate::inner::MapImpl<K, crate::inner::Values<V>, S> as IntoIterator>::IntoIter,
+    >,
+}
+
+impl<'rg, K, V, S> Iterator for ReadGuardIter<'rg, K, V, S>
+where
+    K: Eq + Hash,
+    S: BuildHasher,
+{
+    type Item = (&'rg K, &'rg [V]);
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter
+            .as_mut()
+            .and_then(|iter| iter.next().map(|(k, v)| (k, &v[..])))
+    }
+}

--- a/src/write.rs
+++ b/src/write.rs
@@ -28,23 +28,23 @@ use std::collections::hash_map::Entry;
 /// let (r, mut w) = evmap::new();
 ///
 /// // the map is uninitialized, so all lookups should return None
-/// assert_eq!(r.get_and(&x.0, |rs| rs.len()), None);
+/// assert_eq!(r.get(&x.0).map(|rs| rs.len()), None);
 ///
 /// w.refresh();
 ///
 /// // after the first refresh, it is empty, but ready
-/// assert_eq!(r.get_and(&x.0, |rs| rs.len()), None);
+/// assert_eq!(r.get(&x.0).map(|rs| rs.len()), None);
 ///
 /// w.insert(x.0, x);
 ///
 /// // it is empty even after an add (we haven't refresh yet)
-/// assert_eq!(r.get_and(&x.0, |rs| rs.len()), None);
+/// assert_eq!(r.get(&x.0).map(|rs| rs.len()), None);
 ///
 /// w.refresh();
 ///
 /// // but after the swap, the record is there!
-/// assert_eq!(r.get_and(&x.0, |rs| rs.len()), Some(1));
-/// assert_eq!(r.get_and(&x.0, |rs| rs.iter().any(|v| v.0 == x.0 && v.1 == x.1)), Some(true));
+/// assert_eq!(r.get(&x.0).map(|rs| rs.len()), Some(1));
+/// assert_eq!(r.get(&x.0).map(|rs| rs.iter().any(|v| v.0 == x.0 && v.1 == x.1)), Some(true));
 /// ```
 pub struct WriteHandle<K, V, M = (), S = RandomState>
 where


### PR DESCRIPTION
Previously, most of the evmap APIs were closure based. Specifically, for
a method like `get`, you had to provide a `then` function that mapped a
reference to a value contained in the map into an owned value. This was
there to ensure that we always reset the parity bit of the epoch after
the read operation completed.

That API was fairly annoying to work with. This patch switches to a new,
guard-based API. Where you would previously write something like:

```rust
map.get_and("foo", |values| {
    /* do stuff with values */
})
```

You can now write:

```rust
let values = map.get("foo");
// do stuff with values
drop(values);
```

Because `get` returns a `ReadGuard`, which `Deref`s to the inner type.
As long as the guard lives, the reference is valid. This API _does_ mean
it's easier to shoot yourself in the foot though. As long as the guard
lives, writers cannot refresh the map, since the guard is still holding
back the next epoch. Make sure you don't do too much work while holding
a guard, and especially blocking work!

This patch also introduces the `read` method on `ReadHandle`. It returns
a `MapReadRef`, which is sort of like getting a guard to the map as a
whole. It allows you to make multiple lookups and the like without
having to increment the epoch each time. It also implements the `Index`
and `IntoIterator` (for `&`) traits.