### PR TITLE
hashbag for large bags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,10 @@ maintenance = { status = "passively-maintained" }
 
 [dependencies]
 indexmap = { version = "1.1.0", optional = true }
-smallvec = { version = "1.0.0", optional = true }
+smallvec = "1.0.0"
+hashbag = "0.1.2"
 bytes = { version = "0.5", optional = true }
 
 [features]
-default = ["smallvec"]
+default = []
 indexed = ["indexmap"]

--- a/src/inner.rs
+++ b/src/inner.rs
@@ -14,7 +14,7 @@ where
     K: Eq + Hash,
     S: BuildHasher,
 {
-    pub(crate) data: MapImpl<K, Values<V>, S>,
+    pub(crate) data: MapImpl<K, Values<V, S>, S>,
     pub(crate) meta: M,
     ready: bool,
 }

--- a/src/inner.rs
+++ b/src/inner.rs
@@ -25,7 +25,7 @@ where
     S: BuildHasher,
 {
     pub(crate) unsafe fn do_drop(&mut self) -> &mut Inner<K, V, M, S> {
-        std::mem::transmute(self)
+        &mut *(self as *mut Self as *mut Inner<K, V, M, S>)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,21 +181,19 @@
 //! approximately twice of that of a regular `HashMap`, and more if writes rarely refresh after
 //! writing.
 //!
-//! # Small Vector Optimization
+//! # Value storage
 //!
-//! By default, the value-set for each key in the map uses the `smallvec` crate to keep a
-//! maximum of one element stored inline with the map, as opposed to separately heap-allocated
-//! with a plain `Vec`. Operations such as `Fit` and `Replace` will automatically switch
-//! back to the inline storage if possible. This is ideal for maps that mostly use one
-//! element per key, as it can improvate memory locality with less indirection.
-//!
-//! If this is undesirable, simple set:
-//!
-//! ```toml
-//! default-features = false
-//! ```
-//!
-//! in the `evmap` dependency entry, and `Vec` will always be used internally.
+//! The values for each key in the map are stored in [`Values`]. Conceptually, each `Values` is a
+//! _bag_ or _multiset_; it can store multiple copies of the same value. `evmap` applies some
+//! cleverness in an attempt to reduce unnecessary allocations and keep the cost of operations on
+//! even large value-bags small. For small bags, `Values` uses the `smallvec` crate. This avoids
+//! allocation entirely for single-element bags, and uses a `Vec` if the bag is relatively small.
+//! For large bags, `Values` uses the `hashbag` crate, which enables `evmap` to efficiently look up
+//! and remove specific elements in the value bag. For bags larger than one element, but smaller
+//! than the threshold for moving to `hashbag`, we use `smallvec` to avoid unnecessary hashing.
+//! Operations such as `Fit` and `Replace` will automatically switch back to the inline storage if
+//! possible. This is ideal for maps that mostly use one element per key, as it can improvate
+//! memory locality with less indirection.
 #![deny(missing_docs, rust_2018_idioms, missing_debug_implementations)]
 
 use std::collections::hash_map::RandomState;
@@ -206,12 +204,15 @@ use std::sync::{atomic, Arc, Mutex};
 mod inner;
 use crate::inner::Inner;
 
+mod values;
+pub use values::Values;
+
 pub(crate) type Epochs = Arc<Mutex<Vec<Arc<atomic::AtomicUsize>>>>;
 
 /// Unary predicate used to retain elements.
 ///
-/// The arguments to the predicate function are the current value in the value-set, and `true` if
-/// this is the first value in the value-set on the second map, or `false` otherwise.
+/// The predicate function is called once for each distinct value, and `true` if this is the
+/// _first_ call to the predicate on the _second_ application of the operation.
 pub struct Predicate<V>(pub(crate) Box<dyn FnMut(&V, bool) -> bool + Send + Sync>);
 
 impl<V> Predicate<V> {
@@ -262,16 +263,16 @@ pub enum Operation<K, V> {
     Purge,
     /// Retains all values matching the given predicate.
     Retain(K, Predicate<V>),
-    /// Shrinks a value-set to it's minimum necessary size, freeing memory
-    /// and potentially improving cache locality if the `smallvec` feature is used.
+    /// Shrinks [`Values`] to their minimum necessary size, freeing memory
+    /// and potentially improving cache locality.
     ///
-    /// If no key is given, all value-sets will shrink to fit.
+    /// If no key is given, all `Values` will shrink to fit.
     Fit(Option<K>),
-    /// Reserves capacity for some number of additional elements in a value-set,
-    /// or creates an empty value-set for this key with the given capacity if
-    /// it doesn't already exist.
+    /// Reserves capacity for some number of additional elements in [`Values`]
+    /// for the given key. If the given key does not exist, allocate an empty
+    /// `Values` with the given capacity.
     ///
-    /// This can improve performance by pre-allocating space for large value-sets.
+    /// This can improve performance by pre-allocating space for large bags of values.
     Reserve(K, usize),
 }
 
@@ -360,7 +361,7 @@ where
     where
         K: Eq + Hash + Clone,
         S: BuildHasher + Clone,
-        V: Eq + ShallowCopy,
+        V: Eq + Hash + Clone + ShallowCopy,
         M: 'static + Clone,
     {
         let epochs = Default::default();
@@ -388,7 +389,7 @@ pub fn new<K, V>() -> (
 )
 where
     K: Eq + Hash + Clone,
-    V: Eq + ShallowCopy,
+    V: Eq + Hash + Clone + ShallowCopy,
 {
     Options::default().construct()
 }
@@ -405,7 +406,7 @@ pub fn with_meta<K, V, M>(
 )
 where
     K: Eq + Hash + Clone,
-    V: Eq + ShallowCopy,
+    V: Eq + Hash + Clone + ShallowCopy,
     M: 'static + Clone,
 {
     Options::default().with_meta(meta).construct()
@@ -421,7 +422,7 @@ pub fn with_hasher<K, V, M, S>(
 ) -> (ReadHandle<K, V, M, S>, WriteHandle<K, V, M, S>)
 where
     K: Eq + Hash + Clone,
-    V: Eq + ShallowCopy,
+    V: Eq + Hash + Clone + ShallowCopy,
     M: 'static + Clone,
     S: BuildHasher + Clone,
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,6 +195,7 @@
 //! possible. This is ideal for maps that mostly use one element per key, as it can improvate
 //! memory locality with less indirection.
 #![deny(missing_docs, rust_2018_idioms, missing_debug_implementations)]
+#![allow(clippy::type_complexity)]
 
 use std::collections::hash_map::RandomState;
 use std::fmt;

--- a/src/read/factory.rs
+++ b/src/read/factory.rs
@@ -3,6 +3,7 @@ use crate::inner::Inner;
 
 use std::collections::hash_map::RandomState;
 use std::hash::{BuildHasher, Hash};
+use std::mem::ManuallyDrop;
 use std::sync::atomic::AtomicPtr;
 use std::{fmt, sync};
 
@@ -17,7 +18,7 @@ where
     K: Eq + Hash,
     S: BuildHasher,
 {
-    pub(super) inner: sync::Arc<AtomicPtr<Inner<K, V, M, S>>>,
+    pub(super) inner: sync::Arc<AtomicPtr<Inner<K, ManuallyDrop<V>, M, S>>>,
     pub(super) epochs: crate::Epochs,
 }
 

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -322,7 +322,7 @@ mod test {
     #[test]
     fn reserve_and_fit() {
         const MIN: usize = (1 << 4) + 1;
-        const MAX: usize = (1 << 6);
+        const MAX: usize = 1 << 6;
 
         let (r, mut w) = new();
 

--- a/src/read/read_ref.rs
+++ b/src/read/read_ref.rs
@@ -65,7 +65,7 @@ where
     /// Note that not all writes will be included with this read -- only those that have been
     /// refreshed by the writer. If no refresh has happened, or the map has been destroyed, this
     /// function returns `None`.
-    pub fn get<'a, Q: ?Sized>(&'a self, key: &'_ Q) -> Option<&'a Values<V>>
+    pub fn get<'a, Q: ?Sized>(&'a self, key: &'_ Q) -> Option<&'a Values<V, S>>
     where
         K: Borrow<Q>,
         Q: Hash + Eq,
@@ -108,7 +108,7 @@ where
     Q: Eq + Hash + ?Sized,
     S: BuildHasher,
 {
-    type Output = Values<V>;
+    type Output = Values<V, S>;
     fn index(&self, key: &Q) -> &Self::Output {
         self.get(key).unwrap()
     }
@@ -119,7 +119,7 @@ where
     K: Eq + Hash,
     S: BuildHasher,
 {
-    type Item = (&'rg K, &'rg Values<V>);
+    type Item = (&'rg K, &'rg Values<V, S>);
     type IntoIter = ReadGuardIter<'rg, K, V, S>;
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
@@ -134,7 +134,7 @@ where
     S: BuildHasher,
 {
     iter: Option<
-        <&'rg crate::inner::MapImpl<K, Values<ManuallyDrop<V>>, S> as IntoIterator>::IntoIter,
+        <&'rg crate::inner::MapImpl<K, Values<ManuallyDrop<V>, S>, S> as IntoIterator>::IntoIter,
     >,
 }
 
@@ -143,7 +143,7 @@ where
     K: Eq + Hash,
     S: BuildHasher,
 {
-    type Item = (&'rg K, &'rg Values<V>);
+    type Item = (&'rg K, &'rg Values<V, S>);
     fn next(&mut self) -> Option<Self::Item> {
         self.iter
             .as_mut()

--- a/src/read/read_ref.rs
+++ b/src/read/read_ref.rs
@@ -30,7 +30,7 @@ where
     ///
     /// Be careful with this function! While the iteration is ongoing, any writer that tries to
     /// refresh will block waiting on this reader to finish.
-    pub fn iter<'a>(&'a self) -> ReadGuardIter<'a, K, V, S> {
+    pub fn iter(&self) -> ReadGuardIter<'_, K, V, S> {
         ReadGuardIter {
             iter: self.guard.as_ref().map(|rg| rg.data.iter()),
         }

--- a/src/shallow_copy.rs
+++ b/src/shallow_copy.rs
@@ -29,6 +29,8 @@ use std::ops::{Deref, DerefMut};
 pub trait ShallowCopy {
     /// Perform an aliasing copy of this value.
     ///
+    /// # Safety
+    ///
     /// The use of this method is *only* safe if the values involved are never mutated, and only
     /// one of the copies is dropped; the remaining copies must be forgotten with `mem::forget`.
     unsafe fn shallow_copy(&self) -> ManuallyDrop<Self>;

--- a/src/shallow_copy.rs
+++ b/src/shallow_copy.rs
@@ -1,5 +1,6 @@
 //! Types that can be cheaply aliased.
 
+use std::mem::ManuallyDrop;
 use std::ops::{Deref, DerefMut};
 
 /// Types that implement this trait can be cheaply copied by (potentially) aliasing the data they
@@ -10,12 +11,14 @@ use std::ops::{Deref, DerefMut};
 ///
 /// ```rust
 /// # use evmap::ShallowCopy;
+/// use std::mem::ManuallyDrop;
+///
 /// #[derive(Copy, Clone)]
 /// struct T;
 ///
 /// impl ShallowCopy for T {
-///     unsafe fn shallow_copy(&mut self) -> Self {
-///         *self
+///     unsafe fn shallow_copy(&self) -> ManuallyDrop<Self> {
+///         ManuallyDrop::new(*self)
 ///     }
 /// }
 /// ```
@@ -28,7 +31,7 @@ pub trait ShallowCopy {
     ///
     /// The use of this method is *only* safe if the values involved are never mutated, and only
     /// one of the copies is dropped; the remaining copies must be forgotten with `mem::forget`.
-    unsafe fn shallow_copy(&mut self) -> Self;
+    unsafe fn shallow_copy(&self) -> ManuallyDrop<Self>;
 }
 
 use std::sync::Arc;
@@ -36,8 +39,8 @@ impl<T> ShallowCopy for Arc<T>
 where
     T: ?Sized,
 {
-    unsafe fn shallow_copy(&mut self) -> Self {
-        Arc::from_raw(&**self as *const _)
+    unsafe fn shallow_copy(&self) -> ManuallyDrop<Self> {
+        ManuallyDrop::new(Arc::from_raw(&**self as *const _))
     }
 }
 
@@ -46,8 +49,8 @@ impl<T> ShallowCopy for Rc<T>
 where
     T: ?Sized,
 {
-    unsafe fn shallow_copy(&mut self) -> Self {
-        Rc::from_raw(&**self as *const _)
+    unsafe fn shallow_copy(&self) -> ManuallyDrop<Self> {
+        ManuallyDrop::new(Rc::from_raw(&**self as *const _))
     }
 }
 
@@ -55,35 +58,35 @@ impl<T> ShallowCopy for Box<T>
 where
     T: ?Sized,
 {
-    unsafe fn shallow_copy(&mut self) -> Self {
-        Box::from_raw(&mut **self as *mut _)
+    unsafe fn shallow_copy(&self) -> ManuallyDrop<Self> {
+        ManuallyDrop::new(Box::from_raw(&**self as *const _ as *mut _))
     }
 }
 
 impl ShallowCopy for String {
-    unsafe fn shallow_copy(&mut self) -> Self {
-        let buf = self.as_bytes_mut().as_mut_ptr();
+    unsafe fn shallow_copy(&self) -> ManuallyDrop<Self> {
+        let buf = self.as_bytes().as_ptr();
         let len = self.len();
         let cap = self.capacity();
-        String::from_raw_parts(buf, len, cap)
+        ManuallyDrop::new(String::from_raw_parts(buf as *mut _, len, cap))
     }
 }
 
 impl<T> ShallowCopy for Vec<T> {
-    unsafe fn shallow_copy(&mut self) -> Self {
-        let ptr = self.as_mut_ptr();
+    unsafe fn shallow_copy(&self) -> ManuallyDrop<Self> {
+        let ptr = self.as_ptr() as *mut _;
         let len = self.len();
         let cap = self.capacity();
-        Vec::from_raw_parts(ptr, len, cap)
+        ManuallyDrop::new(Vec::from_raw_parts(ptr, len, cap))
     }
 }
 
 #[cfg(feature = "bytes")]
 impl ShallowCopy for bytes::Bytes {
-    unsafe fn shallow_copy(&mut self) -> Self {
+    unsafe fn shallow_copy(&self) -> ManuallyDrop<Self> {
         let len = self.len();
         let buf: &'static [u8] = std::slice::from_raw_parts(self.as_ptr(), len);
-        bytes::Bytes::from_static(buf)
+        ManuallyDrop::new(bytes::Bytes::from_static(buf))
     }
 }
 
@@ -91,8 +94,8 @@ impl<'a, T> ShallowCopy for &'a T
 where
     T: ?Sized,
 {
-    unsafe fn shallow_copy(&mut self) -> Self {
-        &*self
+    unsafe fn shallow_copy(&self) -> ManuallyDrop<Self> {
+        ManuallyDrop::new(&*self)
     }
 }
 
@@ -114,8 +117,8 @@ impl<T> ShallowCopy for CopyValue<T>
 where
     T: Copy,
 {
-    unsafe fn shallow_copy(&mut self) -> Self {
-        CopyValue(self.0)
+    unsafe fn shallow_copy(&self) -> ManuallyDrop<Self> {
+        ManuallyDrop::new(CopyValue(self.0))
     }
 }
 
@@ -135,8 +138,8 @@ impl<T> DerefMut for CopyValue<T> {
 macro_rules! impl_shallow_copy_for_copy_primitives {
     ($($t:ty)*) => ($(
         impl ShallowCopy for $t {
-            unsafe fn shallow_copy(&mut self) -> Self {
-                *self
+            unsafe fn shallow_copy(&self) -> ManuallyDrop<Self> {
+                ManuallyDrop::new(*self)
             }
         }
     )*)
@@ -152,8 +155,8 @@ macro_rules! tuple_impls {
     )+) => {
         $(
             impl<$($T:ShallowCopy),+> ShallowCopy for ($($T,)+) {
-                unsafe fn shallow_copy(&mut self) -> Self {
-                    ($(self.$idx.shallow_copy(),)+)
+                unsafe fn shallow_copy(&self) -> ManuallyDrop<Self> {
+                    ManuallyDrop::new(($(ManuallyDrop::into_inner(self.$idx.shallow_copy()),)+))
                 }
             }
         )+

--- a/src/values.rs
+++ b/src/values.rs
@@ -1,0 +1,260 @@
+use std::borrow::Borrow;
+use std::hash::Hash;
+use std::mem::ManuallyDrop;
+
+const BAG_THRESHOLD: usize = 32;
+
+/// A bag of values for a given key in the evmap.
+#[derive(Debug)]
+#[repr(transparent)]
+pub struct Values<T>(ValuesInner<T>);
+
+#[derive(Debug)]
+enum ValuesInner<T> {
+    Short(smallvec::SmallVec<[T; 1]>),
+    Long(hashbag::HashBag<T>),
+}
+
+impl<T> Values<ManuallyDrop<T>> {
+    pub(crate) fn user_friendly(&self) -> &Values<T> {
+        unsafe { std::mem::transmute(self) }
+    }
+}
+
+impl<T> Values<T> {
+    /// Returns the number of values.
+    pub fn len(&self) -> usize {
+        match self.0 {
+            ValuesInner::Short(ref v) => v.len(),
+            ValuesInner::Long(ref v) => v.len(),
+        }
+    }
+
+    /// Returns the number of values that can be held without reallocating.
+    pub fn capacity(&self) -> usize {
+        match self.0 {
+            ValuesInner::Short(ref v) => v.capacity(),
+            ValuesInner::Long(ref v) => v.capacity(),
+        }
+    }
+
+    /// An iterator visiting all elements in arbitrary order.
+    ///
+    /// The iterator element type is &'a T.
+    pub fn iter(&self) -> ValuesIter<'_, T> {
+        match self.0 {
+            ValuesInner::Short(ref v) => ValuesIter::Short(v.iter()),
+            ValuesInner::Long(ref v) => ValuesIter::Long(v.iter()),
+        }
+    }
+
+    /// Returns true if a value matching `value` is among the stored values.
+    ///
+    /// The value may be any borrowed form of `T`, but [`Hash`] and [`Eq`] on the borrowed form
+    /// *must* match those for the value type.
+    pub fn contains<Q: ?Sized>(&self, value: &Q) -> bool
+    where
+        T: Borrow<Q>,
+        Q: Eq + Hash,
+        T: Eq + Hash,
+    {
+        match self.0 {
+            ValuesInner::Short(ref v) => v.iter().any(|v| v.borrow() == value),
+            ValuesInner::Long(ref v) => v.contains(value) != 0,
+        }
+    }
+}
+
+impl<'a, T> IntoIterator for &'a Values<T> {
+    type IntoIter = ValuesIter<'a, T>;
+    type Item = &'a T;
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+#[derive(Debug)]
+pub enum ValuesIter<'a, T> {
+    #[doc(hidden)]
+    Short(<&'a smallvec::SmallVec<[T; 1]> as IntoIterator>::IntoIter),
+    #[doc(hidden)]
+    Long(<&'a hashbag::HashBag<T> as IntoIterator>::IntoIter),
+}
+
+impl<'a, T> Iterator for ValuesIter<'a, T> {
+    type Item = &'a T;
+    fn next(&mut self) -> Option<Self::Item> {
+        match *self {
+            Self::Short(ref mut it) => it.next(),
+            Self::Long(ref mut it) => it.next(),
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        match self {
+            Self::Short(it) => it.size_hint(),
+            Self::Long(it) => it.size_hint(),
+        }
+    }
+}
+
+impl<'a, T> ExactSizeIterator for ValuesIter<'a, T>
+where
+    <&'a smallvec::SmallVec<[T; 1]> as IntoIterator>::IntoIter: ExactSizeIterator,
+    <&'a hashbag::HashBag<T> as IntoIterator>::IntoIter: ExactSizeIterator,
+{
+}
+
+impl<'a, T> std::iter::FusedIterator for ValuesIter<'a, T>
+where
+    <&'a smallvec::SmallVec<[T; 1]> as IntoIterator>::IntoIter: std::iter::FusedIterator,
+    <&'a hashbag::HashBag<T> as IntoIterator>::IntoIter: std::iter::FusedIterator,
+{
+}
+
+impl<T> Values<T>
+where
+    T: Eq + Hash + Clone,
+{
+    pub(crate) fn new() -> Self {
+        Self(ValuesInner::Short(smallvec::SmallVec::new()))
+    }
+
+    pub(crate) fn with_capacity(capacity: usize) -> Self {
+        if capacity > BAG_THRESHOLD {
+            Self(ValuesInner::Long(hashbag::HashBag::with_capacity(capacity)))
+        } else {
+            Self(ValuesInner::Short(smallvec::SmallVec::with_capacity(
+                capacity,
+            )))
+        }
+    }
+
+    pub(crate) fn shrink_to_fit(&mut self) {
+        match self.0 {
+            ValuesInner::Short(ref mut v) => v.shrink_to_fit(),
+            ValuesInner::Long(ref mut v) => {
+                // here, we actually want to be clever
+                // we want to potentially "downgrade" from a Long to a Short
+                if v.len() < BAG_THRESHOLD {
+                    let mut short = smallvec::SmallVec::with_capacity(v.len());
+                    for (row, n) in v.drain() {
+                        // there may be more than one instance of row in the bag. if there is, we
+                        // need to clone them before inserting them into the smallvec. if we did
+                        // not (if we instead did a shallow copy), then dropping the second
+                        // occurrence of a duplicated element on second apply() would be a
+                        // double-free. this is definitely a little unfortunate, as it means not
+                        // only does T: Clone, but _also_ we have to clone a value that technically
+                        // the user has already given us a clone of (when they initially pushed
+                        // it!).
+                        for _ in 1..n {
+                            short.push(row.clone());
+                        }
+                        short.push(row);
+                    }
+                    std::mem::replace(&mut self.0, ValuesInner::Short(short));
+                } else {
+                    v.shrink_to_fit();
+                }
+            }
+        }
+    }
+
+    pub(crate) fn clear(&mut self) {
+        // NOTE: we do _not_ downgrade to Short here -- shrink is for that
+        match self.0 {
+            ValuesInner::Short(ref mut v) => v.clear(),
+            ValuesInner::Long(ref mut v) => v.clear(),
+        }
+    }
+
+    pub(crate) fn swap_remove(&mut self, value: &T) {
+        match self.0 {
+            ValuesInner::Short(ref mut v) => {
+                if let Some(i) = v.iter().position(|v| v == value) {
+                    v.swap_remove(i);
+                }
+            }
+            ValuesInner::Long(ref mut v) => {
+                v.remove(value);
+            }
+        }
+    }
+
+    fn to_long(&mut self, capacity: usize) {
+        if let ValuesInner::Short(ref mut v) = self.0 {
+            let mut long = hashbag::HashBag::with_capacity(capacity);
+            // NOTE: this _may_ drop some values since the bag does not keep duplicates.
+            // that should be fine -- if we drop for the first time, we're dropping
+            // ManuallyDrop, which won't actually drop the shallow copies. when we drop for
+            // the second time, we do the actual dropping. since second application has the
+            // exact same original state, this change from short/long should occur exactly
+            // the same.
+            long.extend(v.drain(..));
+            std::mem::replace(&mut self.0, ValuesInner::Long(long));
+        }
+    }
+
+    pub(crate) fn reserve(&mut self, additional: usize) {
+        match self.0 {
+            ValuesInner::Short(ref mut v) => {
+                let n = v.len() + additional;
+                if n >= BAG_THRESHOLD {
+                    self.to_long(n);
+                } else {
+                    v.reserve(additional)
+                }
+            }
+            ValuesInner::Long(ref mut v) => v.reserve(additional),
+        }
+    }
+
+    pub(crate) fn push(&mut self, value: T) {
+        match self.0 {
+            ValuesInner::Short(ref mut v) => {
+                // we may want to upgrade to a Long..
+                let n = v.len() + 1;
+                if n >= BAG_THRESHOLD {
+                    self.to_long(n);
+                    if let ValuesInner::Long(ref mut v) = self.0 {
+                        v.insert(value);
+                    } else {
+                        unreachable!();
+                    }
+                } else {
+                    v.push(value);
+                }
+            }
+            ValuesInner::Long(ref mut v) => {
+                v.insert(value);
+            }
+        }
+    }
+
+    pub(crate) fn retain<F>(&mut self, mut f: F)
+    where
+        F: FnMut(&T) -> bool,
+    {
+        match self.0 {
+            ValuesInner::Short(ref mut v) => v.retain(|v| f(&*v)),
+            ValuesInner::Long(ref mut v) => v.retain(|v, n| if f(v) { n } else { 0 }),
+        }
+    }
+}
+
+impl<A> std::iter::FromIterator<A> for Values<A>
+where
+    A: Hash + Eq,
+{
+    fn from_iter<T>(iter: T) -> Self
+    where
+        T: IntoIterator<Item = A>,
+    {
+        let iter = iter.into_iter();
+        if iter.size_hint().0 > BAG_THRESHOLD {
+            Self(ValuesInner::Long(hashbag::HashBag::from_iter(iter)))
+        } else {
+            Self(ValuesInner::Short(smallvec::SmallVec::from_iter(iter)))
+        }
+    }
+}

--- a/src/write.rs
+++ b/src/write.rs
@@ -1,9 +1,11 @@
 use super::{Operation, Predicate, ShallowCopy};
-use crate::inner::{Inner, Values};
+use crate::inner::Inner;
 use crate::read::ReadHandle;
+use crate::values::Values;
 
 use std::collections::hash_map::RandomState;
 use std::hash::{BuildHasher, Hash};
+use std::mem::ManuallyDrop;
 use std::sync::atomic;
 use std::sync::{Arc, MutexGuard};
 use std::{fmt, mem, thread};
@@ -50,11 +52,11 @@ pub struct WriteHandle<K, V, M = (), S = RandomState>
 where
     K: Eq + Hash + Clone,
     S: BuildHasher + Clone,
-    V: Eq + ShallowCopy,
+    V: Eq + Hash + Clone + ShallowCopy,
     M: 'static + Clone,
 {
     epochs: crate::Epochs,
-    w_handle: Option<Box<Inner<K, V, M, S>>>,
+    w_handle: Option<Box<Inner<K, ManuallyDrop<V>, M, S>>>,
     oplog: Vec<Operation<K, V>>,
     swap_index: usize,
     r_handle: ReadHandle<K, V, M, S>,
@@ -68,7 +70,7 @@ impl<K, V, M, S> fmt::Debug for WriteHandle<K, V, M, S>
 where
     K: Eq + Hash + Clone + fmt::Debug,
     S: BuildHasher + Clone,
-    V: Eq + ShallowCopy + fmt::Debug,
+    V: Eq + Hash + Clone + ShallowCopy + fmt::Debug,
     M: 'static + Clone + fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -86,14 +88,14 @@ where
 }
 
 pub(crate) fn new<K, V, M, S>(
-    w_handle: Inner<K, V, M, S>,
+    w_handle: Inner<K, ManuallyDrop<V>, M, S>,
     epochs: crate::Epochs,
     r_handle: ReadHandle<K, V, M, S>,
 ) -> WriteHandle<K, V, M, S>
 where
     K: Eq + Hash + Clone,
     S: BuildHasher + Clone,
-    V: Eq + ShallowCopy,
+    V: Eq + Hash + Clone + ShallowCopy,
     M: 'static + Clone,
 {
     let m = w_handle.meta.clone();
@@ -114,7 +116,7 @@ impl<K, V, M, S> Drop for WriteHandle<K, V, M, S>
 where
     K: Eq + Hash + Clone,
     S: BuildHasher + Clone,
-    V: Eq + ShallowCopy,
+    V: Eq + Hash + Clone + ShallowCopy,
     M: 'static + Clone,
 {
     fn drop(&mut self) {
@@ -146,26 +148,18 @@ where
 
         let w_handle = &mut self.w_handle.as_mut().unwrap().data;
 
-        #[cfg(not(feature = "indexed"))]
-        let drain = w_handle.drain();
-        #[cfg(feature = "indexed")]
-        let drain = w_handle.drain(..);
-
         // all readers have now observed the NULL, so we own both handles.
         // all records are duplicated between w_handle and r_handle.
         // since the two maps are exactly equal, we need to make sure that we *don't* call the
         // destructors of any of the values that are in our map, as they'll all be called when the
-        // last read handle goes out of scope.
-        for (_, mut vs) in drain {
-            for v in vs.drain(..) {
-                mem::forget(v);
-            }
-        }
+        // last read handle goes out of scope. to do so, we first clear w_handle, which won't drop
+        // any elements since its values are kept as ManuallyDrop:
+        w_handle.clear();
 
-        // then we drop r_handle, which will free all the records. this is safe, since we know that
-        // no readers are using this pointer anymore (due to the .wait() following swapping the
-        // pointer with NULL).
-        drop(unsafe { Box::from_raw(r_handle) });
+        // then we transmute r_handle to remove the ManuallyDrop, and then drop it, which will free
+        // all the records. this is safe, since we know that no readers are using this pointer
+        // anymore (due to the .wait() following swapping the pointer with NULL).
+        drop(unsafe { Box::from_raw(r_handle as *mut Inner<K, V, M, S>) });
     }
 }
 
@@ -173,7 +167,7 @@ impl<K, V, M, S> WriteHandle<K, V, M, S>
 where
     K: Eq + Hash + Clone,
     S: BuildHasher + Clone,
-    V: Eq + ShallowCopy,
+    V: Eq + Hash + Clone + ShallowCopy,
     M: 'static + Clone,
 {
     fn wait(&mut self, epochs: &mut MutexGuard<'_, Vec<Arc<atomic::AtomicUsize>>>) {
@@ -261,7 +255,9 @@ where
                     .extend(r_handle.data.iter_mut().map(|(k, vs)| {
                         (
                             k.clone(),
-                            vs.iter_mut().map(|v| unsafe { v.shallow_copy() }).collect(),
+                            vs.iter()
+                                .map(|v| unsafe { (&**v).shallow_copy() })
+                                .collect(),
                         )
                     }));
             }
@@ -282,7 +278,8 @@ where
                 // removed (since those removals have already happened on the other map, and
                 // without calling their destructor).
                 for op in self.oplog.drain(0..self.swap_index) {
-                    Self::apply_second(w_handle, op);
+                    // because we are applying second, we _do_ want to perform drops
+                    Self::apply_second(unsafe { w_handle.do_drop() }, op);
                 }
             }
             // the rest have to be cloned because they'll also be needed by the r_handle map
@@ -384,26 +381,26 @@ where
         } else {
             // we know there are no outstanding w_handle readers, so we can modify it directly!
             let inner = self.w_handle.as_mut().unwrap();
-            Self::apply_second(inner, op);
+            // because we are applying second, we _do_ want to perform drops
+            Self::apply_second(unsafe { inner.do_drop() }, op);
             // NOTE: since we didn't record this in the oplog, r_handle *must* clone w_handle
         }
 
         self
     }
 
-    /// Add the given value to the value-set of the given key.
+    /// Add the given value to the value-bag of the given key.
     ///
-    /// The updated value-set will only be visible to readers after the next call to `refresh()`.
+    /// The updated value-bag will only be visible to readers after the next call to `refresh()`.
     pub fn insert(&mut self, k: K, v: V) -> &mut Self {
         self.add_op(Operation::Add(k, v))
     }
 
-    /// Replace the value-set of the given key with the given value.
+    /// Replace the value-bag of the given key with the given value.
     ///
-    /// With the `smallvec` feature enabled, replacing the value will automatically
-    /// deallocate any heap storage and place the new value back into
-    /// the `SmallVec` inline storage. This can improve cache locality for common
-    /// cases where the value-set is only ever a single element.
+    /// Replacing the value will automatically deallocate any heap storage and place the new value
+    /// back into the `SmallVec` inline storage. This can improve cache locality for common
+    /// cases where the value-bag is only ever a single element.
     ///
     /// See [the doc section on this](./index.html#small-vector-optimization) for more information.
     ///
@@ -412,32 +409,32 @@ where
         self.add_op(Operation::Replace(k, v))
     }
 
-    /// Clear the value-set of the given key, without removing it.
+    /// Clear the value-bag of the given key, without removing it.
     ///
-    /// If a value-set already exists, this will clear it but leave the
-    /// allocated memory intact for reuse, or if no associated value-set exists
-    /// an empty value-set will be created for the given key.
+    /// If a value-bag already exists, this will clear it but leave the
+    /// allocated memory intact for reuse, or if no associated value-bag exists
+    /// an empty value-bag will be created for the given key.
     ///
     /// The new value will only be visible to readers after the next call to `refresh()`.
     pub fn clear(&mut self, k: K) -> &mut Self {
         self.add_op(Operation::Clear(k))
     }
 
-    /// Remove the given value from the value-set of the given key.
+    /// Remove the given value from the value-bag of the given key.
     ///
-    /// The updated value-set will only be visible to readers after the next call to `refresh()`.
+    /// The updated value-bag will only be visible to readers after the next call to `refresh()`.
     pub fn remove(&mut self, k: K, v: V) -> &mut Self {
         self.add_op(Operation::Remove(k, v))
     }
 
-    /// Remove the value-set for the given key.
+    /// Remove the value-bag for the given key.
     ///
-    /// The value-set will only disappear from readers after the next call to `refresh()`.
+    /// The value-bag will only disappear from readers after the next call to `refresh()`.
     pub fn empty(&mut self, k: K) -> &mut Self {
         self.add_op(Operation::Empty(k))
     }
 
-    /// Purge all value-sets from the map.
+    /// Purge all value-bags from the map.
     ///
     /// The map will only appear empty to readers after the next call to `refresh()`.
     ///
@@ -448,7 +445,7 @@ where
 
     /// Retain elements for the given key using the provided predicate function.
     ///
-    /// The remaining value-set will only be visible to readers after the next call to `refresh()`
+    /// The remaining value-bag will only be visible to readers after the next call to `refresh()`
     ///
     /// Note that the given closure is called _twice_ for each element, once when called, and once
     /// on swap. It _must_ retain the same elements each time, otherwise a value may exist in one
@@ -458,13 +455,13 @@ where
     /// `false` the second time would free the value, but leave an aliased pointer to it in the
     /// other side of the map.
     ///
-    /// The arguments to the predicate function are the current value in the value-set, and `true`
-    /// if this is the first value in the value-set on the second map, or `false` otherwise. Use
+    /// The arguments to the predicate function are the current value in the value-bag, and `true`
+    /// if this is the first value in the value-bag on the second map, or `false` otherwise. Use
     /// the second argument to know when to reset any closure-local state to ensure deterministic
     /// operation.
     ///
     /// So, stated plainly, the given closure _must_ return the same order of true/false for each
-    /// of the two iterations over the value-set. That is, the sequence of returned booleans before
+    /// of the two iterations over the value-bag. That is, the sequence of returned booleans before
     /// the second argument is true must be exactly equal to the sequence of returned booleans
     /// at and beyond when the second argument is true.
     pub unsafe fn retain<F>(&mut self, k: K, f: F) -> &mut Self
@@ -474,40 +471,39 @@ where
         self.add_op(Operation::Retain(k, Predicate(Box::new(f))))
     }
 
-    /// Shrinks a value-set to it's minimum necessary size, freeing memory
-    /// and potentially improving cache locality by switching to inline storage
-    /// if the `smallvec` feature is used.
+    /// Shrinks a value-bag to it's minimum necessary size, freeing memory
+    /// and potentially improving cache locality by switching to inline storage.
     ///
-    /// The optimized value-set will only be visible to readers after the next call to `refresh()`
+    /// The optimized value-bag will only be visible to readers after the next call to `refresh()`
     pub fn fit(&mut self, k: K) -> &mut Self {
         self.add_op(Operation::Fit(Some(k)))
     }
 
-    /// Like [`WriteHandle::fit`](#method.fit), but shrinks <b>all</b> value-sets in the map.
+    /// Like [`WriteHandle::fit`](#method.fit), but shrinks <b>all</b> value-bags in the map.
     ///
-    /// The optimized value-sets will only be visible to readers after the next call to `refresh()`
+    /// The optimized value-bags will only be visible to readers after the next call to `refresh()`
     pub fn fit_all(&mut self) -> &mut Self {
         self.add_op(Operation::Fit(None))
     }
 
-    /// Reserves capacity for some number of additional elements in a value-set,
-    /// or creates an empty value-set for this key with the given capacity if
+    /// Reserves capacity for some number of additional elements in a value-bag,
+    /// or creates an empty value-bag for this key with the given capacity if
     /// it doesn't already exist.
     ///
     /// Readers are unaffected by this operation, but it can improve performance
-    /// by pre-allocating space for large value-sets.
+    /// by pre-allocating space for large value-bags.
     pub fn reserve(&mut self, k: K, additional: usize) -> &mut Self {
         self.add_op(Operation::Reserve(k, additional))
     }
 
     #[cfg(feature = "indexed")]
-    /// Remove the value-set for a key at a specified index.
+    /// Remove the value-bag for a key at a specified index.
     ///
     /// This is effectively random removal.
-    /// The value-set will only disappear from readers after the next call to `refresh()`.
+    /// The value-bag will only disappear from readers after the next call to `refresh()`.
     ///
     /// Note that this does a _swap-remove_, so use it carefully.
-    pub fn empty_at_index(&mut self, index: usize) -> Option<(&K, &[V])> {
+    pub fn empty_at_index(&mut self, index: usize) -> Option<(&K, &Values<V>)> {
         self.add_op(Operation::EmptyRandom(index));
         // the actual emptying won't happen until refresh(), which needs &mut self
         // so it's okay for us to return the references here
@@ -518,36 +514,31 @@ where
         // r_handle side, but not to the w_handle (will be applied on the next swap). We must make
         // sure that we read the most up to date map here.
         let inner = self.r_handle.inner.load(atomic::Ordering::SeqCst);
-        unsafe { (*inner).data.get_index(index) }.map(|(k, vs)| (k, &vs[..]))
+        unsafe { (*inner).data.get_index(index) }.map(|(k, vs)| (k, vs.user_friendly()))
     }
 
     /// Apply ops in such a way that no values are dropped, only forgotten
-    fn apply_first(inner: &mut Inner<K, V, M, S>, op: &mut Operation<K, V>) {
+    fn apply_first(inner: &mut Inner<K, ManuallyDrop<V>, M, S>, op: &mut Operation<K, V>) {
         match *op {
             Operation::Replace(ref key, ref mut value) => {
                 let vs = inner.data.entry(key.clone()).or_insert_with(Values::new);
 
-                unsafe {
-                    // truncate vector without dropping values
-                    vs.set_len(0);
-                }
+                // truncate vector
+                vs.clear();
 
-                // implicit shrink_to_fit on replace op when using smallvec,
-                // as it will switch back to inline allocation for the subsequent push.
-                #[cfg(feature = "smallvec")]
+                // implicit shrink_to_fit on replace op
+                // so it will switch back to inline allocation for the subsequent push.
                 vs.shrink_to_fit();
 
                 vs.push(unsafe { value.shallow_copy() });
             }
-            Operation::Clear(ref key) => match inner.data.entry(key.clone()) {
-                Entry::Occupied(mut entry) => unsafe {
-                    // truncate vector without dropping values
-                    entry.get_mut().set_len(0);
-                },
-                Entry::Vacant(entry) => {
-                    entry.insert(Values::new());
-                }
-            },
+            Operation::Clear(ref key) => {
+                inner
+                    .data
+                    .entry(key.clone())
+                    .or_insert_with(Values::new)
+                    .clear();
+            }
             Operation::Add(ref key, ref mut value) => {
                 inner
                     .data
@@ -557,67 +548,32 @@ where
             }
             Operation::Empty(ref key) => {
                 #[cfg(not(feature = "indexed"))]
-                let rm = inner.data.remove(key);
+                inner.data.remove(key);
                 #[cfg(feature = "indexed")]
-                let rm = inner.data.swap_remove(key);
-                if let Some(mut vs) = rm {
-                    unsafe {
-                        // truncate vector without dropping values
-                        vs.set_len(0);
-                    }
-                }
+                inner.data.swap_remove(key);
             }
             Operation::Purge => {
-                // first, make sure we won't drop any of the values
-                for vs in inner.data.values_mut() {
-                    unsafe {
-                        vs.set_len(0);
-                    }
-                }
-                // then, empty the map
                 inner.data.clear();
             }
             #[cfg(feature = "indexed")]
             Operation::EmptyRandom(index) => {
-                if let Some((_k, mut vs)) = inner.data.swap_remove_index(index) {
-                    // don't run destructors yet -- still in use by other map
-                    unsafe {
-                        vs.set_len(0);
-                    }
-                }
+                inner.data.swap_remove_index(index);
             }
             Operation::Remove(ref key, ref value) => {
                 if let Some(e) = inner.data.get_mut(key) {
-                    // find the first entry that matches all fields
-                    if let Some(i) = e.iter().position(|v| v == value) {
-                        let v = e.swap_remove(i);
-                        // don't run destructor yet -- still in use by other map
-                        mem::forget(v);
-                    }
+                    // remove a matching value from the value set
+                    // safety: this is fine
+                    e.swap_remove(unsafe { std::mem::transmute::<&V, &ManuallyDrop<V>>(value) });
                 }
             }
             Operation::Retain(ref key, ref mut predicate) => {
                 if let Some(e) = inner.data.get_mut(key) {
-                    let mut del = 0;
-                    let len = e.len();
-
-                    // "bubble up" the values we wish to remove, so they can be truncated.
-                    //
-                    // See https://github.com/servo/rust-smallvec/blob/a775b5f74cce0d3c7218608fd9f6fd721bb0f461/lib.rs#L881-L897
-                    // for SmallVec's implementation of `retain`, the only difference being that we
-                    // cannot drop values here, so they are truncated with `set_len`
-                    for i in 0..len {
-                        if !predicate.eval(unsafe { e.get_unchecked(i) }, false) {
-                            del += 1;
-                        } else {
-                            e.swap(i - del, i);
-                        }
-                    }
-
-                    unsafe {
-                        // truncate vector without dropping values
-                        e.set_len(len - del);
-                    }
+                    let mut first = true;
+                    e.retain(move |v| {
+                        let retain = predicate.eval(v, first);
+                        first = false;
+                        retain
+                    });
                 }
             }
             Operation::Fit(ref key) => match key {
@@ -648,16 +604,16 @@ where
         match op {
             Operation::Replace(key, value) => {
                 let v = inner.data.entry(key).or_insert_with(Values::new);
+
+                // we are going second, so we should drop!
                 v.clear();
 
-                #[cfg(feature = "smallvec")]
                 v.shrink_to_fit();
 
                 v.push(value);
             }
             Operation::Clear(key) => {
-                let v = inner.data.entry(key).or_insert_with(Values::new);
-                v.clear();
+                inner.data.entry(key).or_insert_with(Values::new).clear();
             }
             Operation::Add(key, value) => {
                 inner
@@ -682,9 +638,7 @@ where
             Operation::Remove(key, value) => {
                 if let Some(e) = inner.data.get_mut(&key) {
                     // find the first entry that matches all fields
-                    if let Some(i) = e.iter().position(|v| v == &value) {
-                        e.swap_remove(i);
-                    }
+                    e.swap_remove(&value);
                 }
             }
             Operation::Retain(key, mut predicate) => {
@@ -725,7 +679,7 @@ impl<K, V, M, S> Extend<(K, V)> for WriteHandle<K, V, M, S>
 where
     K: Eq + Hash + Clone,
     S: BuildHasher + Clone,
-    V: Eq + ShallowCopy,
+    V: Eq + Hash + Clone + ShallowCopy,
     M: 'static + Clone,
 {
     fn extend<I: IntoIterator<Item = (K, V)>>(&mut self, iter: I) {
@@ -741,7 +695,7 @@ impl<K, V, M, S> Deref for WriteHandle<K, V, M, S>
 where
     K: Eq + Hash + Clone,
     S: BuildHasher + Clone,
-    V: Eq + ShallowCopy,
+    V: Eq + Hash + Clone + ShallowCopy,
     M: 'static + Clone,
 {
     type Target = ReadHandle<K, V, M, S>;

--- a/src/write.rs
+++ b/src/write.rs
@@ -450,7 +450,9 @@ where
     ///
     /// The remaining value-bag will only be visible to readers after the next call to `refresh()`
     ///
-    /// Note that the given closure is called _twice_ for each element, once when called, and once
+    /// # Safety
+    ///
+    /// The given closure is called _twice_ for each element, once when called, and once
     /// on swap. It _must_ retain the same elements each time, otherwise a value may exist in one
     /// map, but not the other, leaving the two maps permanently out-of-sync. This is _really_ bad,
     /// as values are aliased between the maps, and are assumed safe to free when they leave the
@@ -570,7 +572,7 @@ where
                 if let Some(e) = inner.data.get_mut(key) {
                     // remove a matching value from the value set
                     // safety: this is fine
-                    e.swap_remove(unsafe { std::mem::transmute::<&V, &ManuallyDrop<V>>(value) });
+                    e.swap_remove(unsafe { &*(value as *const _ as *const ManuallyDrop<V>) });
                 }
             }
             Operation::Retain(ref key, ref mut predicate) => {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -184,6 +184,22 @@ fn paniced_reader_doesnt_block_writer() {
 }
 
 #[test]
+fn flush_noblock() {
+    let x = ('x', 42);
+
+    let (r, mut w) = evmap::new();
+    w.insert(x.0, x);
+    w.refresh();
+    assert_eq!(r.get(&x.0).map(|rs| rs.len()), Some(1));
+
+    // pin the epoch
+    let _map = r.read();
+    // refresh would hang here, but flush won't
+    assert!(w.pending().is_empty());
+    w.flush();
+}
+
+#[test]
 fn read_after_drop() {
     let x = ('x', 42);
 


### PR DESCRIPTION
This avoids a huge performance collapse when there are many values for a
given key and the user wants to remove one. We do this by switching
large values over to a `hashbag` for backing storage. This change means
that users no longer get a `&[V]`, but instead a `&Values<V>`, and also
that we require `V: Hash + Eq`.

With this change, I also made `smallvec` non-optional.

I also replaced the awkward `mem::forget` code with `ManuallyDrop` which
seems like a much safer approach. The failure mode is now memory leaks
rather than double-frees, which seems like a huge win.