### PR TITLE
WIP: ShallowCopy for Option<T> (and more)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,6 +3,14 @@ jobs:
    parameters:
      minrust: 1.40.0
      codecov_token: $(CODECOV_TOKEN_SECRET)
+ - job: derive
+   displayName: "Test evmap-derive"
+   pool:
+     vmImage: ubuntu-latest
+   steps:
+     - template: install-rust.yml@templates
+     - script: cargo test
+       displayName: cargo test
  - job: benchmark
    displayName: "Check that benchmark compiles"
    pool:

--- a/evmap-derive/Cargo.toml
+++ b/evmap-derive/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "evmap-derive"
+version = "9.0.0"
+edition = "2018"
+
+description = "A lock-free, eventually consistent, concurrent multi-value map."
+readme = "README.md"
+
+authors = ["Jon Gjengset <jon@thesquareplanet.com>"]
+
+documentation = "https://docs.rs/evmap"
+homepage = "https://github.com/jonhoo/rust-evmap"
+repository = "https://github.com/jonhoo/rust-evmap.git"
+
+keywords = ["map","multi-value","lock-free"]
+categories = ["concurrency", "data-structures"]
+
+license = "MIT/Apache-2.0"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = "1.0.16"
+quote = "1.0.2"
+proc-macro2 = "1.0.9"
+
+[dev-dependencies]
+evmap = { path = "../", version = "9.0.0" }
+trybuild = "1.0.24"

--- a/evmap-derive/src/lib.rs
+++ b/evmap-derive/src/lib.rs
@@ -1,0 +1,174 @@
+//! This crate provides procedural derive macros to simplify the usage of `evmap`.
+//!
+//! Currently, only `#[derive(ShallowCopy)]` is supported; see below.
+#![deny(missing_docs)]
+use proc_macro2::{Ident, TokenStream};
+use quote::{format_ident, quote, quote_spanned};
+use syn::spanned::Spanned;
+use syn::{
+    parse_macro_input, parse_quote, Data, DeriveInput, Fields, GenericParam, Generics, Index,
+};
+
+/// Implementation for `#[derive(ShallowCopy)]`
+///
+/// evmap provides the [`ShallowCopy`](evmap::shallow_copy::ShallowCopy) trait, which allows you to
+/// cheaply alias types that don't otherwise implement `Copy`. Basic implementations are provided
+/// for common types such as `String` and `Vec`, but it must be implemented manually for structs
+/// using these types.
+///
+/// This macro attempts to simplify this task. It only works on types whose members all implement
+/// `ShallowCopy`. If this is not possible, consider using
+/// [`CopyValue`](evmap::shallow_copy::CopyValue), `Box`, or `Arc` instead.
+///
+/// ## Usage example
+/// ```
+/// # use evmap_derive::ShallowCopy;
+/// #[derive(ShallowCopy)]
+/// struct Thing { field: i32 }
+///
+/// #[derive(ShallowCopy)]
+/// struct Generic<T> { field: T }
+///
+/// #[derive(ShallowCopy)]
+/// enum Things<T> { One(Thing), Two(Generic<T>) }
+/// ```
+///
+/// ## Generated implementations
+/// The generated implementation calls
+/// [`shallow_copy`](evmap::shallow_copy::ShallowCopy::shallow_copy) on all the members of the
+/// type, and lifts the `ManuallyDrop` wrappers to the top-level return type.
+///
+/// For generic types, the derive adds `ShallowCopy` bounds to all the type parameters.
+///
+/// For instance, for the following code...
+/// ```
+/// # use evmap_derive::ShallowCopy;
+/// #[derive(ShallowCopy)]
+/// struct Generic<T> { field: T }
+/// ```
+/// ...the derive generates...
+/// ```
+/// # use evmap::shallow_copy::ShallowCopy;
+/// # use std::mem::ManuallyDrop;
+/// # struct Generic<T> { field: T }
+/// impl<T: ShallowCopy> ShallowCopy for Generic<T> {
+///     unsafe fn shallow_copy(&self) -> ManuallyDrop<Self> {
+///         ManuallyDrop::new(Self {
+///             field: ManuallyDrop::into_inner(ShallowCopy::shallow_copy(&self.field))
+///         })
+///     }
+/// }
+/// ```
+#[proc_macro_derive(ShallowCopy)]
+pub fn derive_shallow_copy(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let name = input.ident;
+    let generics = add_trait_bounds(input.generics);
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+    let copy = fields(&input.data, &name);
+    proc_macro::TokenStream::from(quote! {
+        impl #impl_generics evmap::shallow_copy::ShallowCopy for #name #ty_generics #where_clause {
+            unsafe fn shallow_copy(&self) -> std::mem::ManuallyDrop<Self> {
+                #copy
+            }
+        }
+    })
+}
+
+fn add_trait_bounds(mut generics: Generics) -> Generics {
+    for param in &mut generics.params {
+        if let GenericParam::Type(ref mut type_param) = *param {
+            type_param
+                .bounds
+                .push(parse_quote!(evmap::shallow_copy::ShallowCopy));
+        }
+    }
+    generics
+}
+
+fn fields(data: &Data, type_name: &Ident) -> TokenStream {
+    match data {
+        Data::Struct(data) => match &data.fields {
+            Fields::Named(fields) => {
+                let recurse = fields.named.iter().map(|f| {
+                        let name = &f.ident;
+                        quote_spanned! {f.span()=>
+                            #name: std::mem::ManuallyDrop::into_inner(
+                                evmap::shallow_copy::ShallowCopy::shallow_copy(&self.#name)
+                            )
+                        }
+                    });
+                quote! {
+                    std::mem::ManuallyDrop::new(Self { #(#recurse,)* })
+                }
+            }
+            Fields::Unnamed(fields) => {
+                let recurse = fields.unnamed.iter().enumerate().map(|(i, f)| {
+                        let index = Index::from(i);
+                        quote_spanned! {f.span()=>
+                            std::mem::ManuallyDrop::into_inner(
+                                evmap::shallow_copy::ShallowCopy::shallow_copy(&self.#index)
+                            )
+                        }
+                    });
+                quote! {
+                    std::mem::ManuallyDrop::new(#type_name(#(#recurse,)*))
+                }
+            }
+            Fields::Unit => quote!(std::mem::ManuallyDrop::new(#type_name)),
+        },
+        Data::Enum(data) => {
+            let recurse = data.variants.iter().map(|f| {
+                let (names, fields) = match &f.fields {
+                    Fields::Named(fields) => {
+                        let field_names = f.fields.iter().map(|field| {
+                            let ident = field.ident.as_ref().unwrap();
+                            quote_spanned! {
+                                field.span()=> #ident
+                            }
+                        });
+                        let recurse = fields.named.iter().map(|f| {
+                            let name = f.ident.as_ref().unwrap();
+                            quote_spanned! {f.span()=>
+                                #name: std::mem::ManuallyDrop::into_inner(
+                                    evmap::shallow_copy::ShallowCopy::shallow_copy(#name)
+                                )
+                            }
+                        });
+                        (quote! { {#(#field_names,)*} }, quote! { { #(#recurse,)* } })
+                    }
+                    Fields::Unnamed(fields) => {
+                        let field_names = f.fields.iter().enumerate().map(|(i, field)| {
+                            let ident = format_ident!("x{}", i);
+                            quote_spanned! {
+                                field.span()=> #ident
+                            }
+                        });
+                        let recurse = fields.unnamed.iter().enumerate().map(|(i, f)| {
+                            let ident = format_ident!("x{}", i);
+                            quote_spanned! {f.span()=>
+                                std::mem::ManuallyDrop::into_inner(
+                                    evmap::shallow_copy::ShallowCopy::shallow_copy(#ident)
+                                )
+                            }
+                        });
+                        (quote! { (#(#field_names,)*) }, quote! { (#(#recurse,)*) })
+                    }
+                    Fields::Unit => {
+                        (quote!(), quote!())
+                    }
+                };
+                let name = &f.ident;
+                quote_spanned! {f.span()=>
+                    #type_name::#name#names => std::mem::ManuallyDrop::new(#type_name::#name#fields)
+                }
+            });
+            quote! {
+                match self {
+                    #(#recurse,)*
+                }
+            }
+        }
+        Data::Union(_) => unimplemented!("Unions are not supported"),
+    }
+}

--- a/evmap-derive/tests/failing/lib.rs
+++ b/evmap-derive/tests/failing/lib.rs
@@ -1,0 +1,25 @@
+use evmap_derive::ShallowCopy;
+use evmap::shallow_copy::ShallowCopy as _;
+
+#[derive(ShallowCopy)]
+struct Broken {
+	f1: i32,
+	f2: std::cell::Cell<()>,
+}
+
+#[derive(ShallowCopy)]
+struct AlsoBroken(i32, std::cell::Cell<()>);
+
+#[derive(ShallowCopy)]
+struct Generic<T> {
+	f1: T
+}
+
+fn main() {
+	let broken = Broken { f1: 0, f2: std::cell::Cell::new(()) };
+	broken.shallow_copy();
+	let also_broken = AlsoBroken(0, std::cell::Cell::new(()));
+	broken.shallow_copy();
+	let generic = Generic { f1: std::cell::Cell::new(()) };
+	generic.shallow_copy();
+}

--- a/evmap-derive/tests/failing/lib.stderr
+++ b/evmap-derive/tests/failing/lib.stderr
@@ -1,0 +1,30 @@
+error[E0277]: the trait bound `std::cell::Cell<()>: evmap::shallow_copy::ShallowCopy` is not satisfied
+ --> $DIR/lib.rs:7:2
+  |
+7 |     f2: std::cell::Cell<()>,
+  |     ^^ the trait `evmap::shallow_copy::ShallowCopy` is not implemented for `std::cell::Cell<()>`
+  |
+  = note: required by `evmap::shallow_copy::ShallowCopy::shallow_copy`
+
+error[E0277]: the trait bound `std::cell::Cell<()>: evmap::shallow_copy::ShallowCopy` is not satisfied
+  --> $DIR/lib.rs:10:10
+   |
+10 | #[derive(ShallowCopy)]
+   |          ^^^^^^^^^^^ the trait `evmap::shallow_copy::ShallowCopy` is not implemented for `std::cell::Cell<()>`
+   |
+   = note: required by `evmap::shallow_copy::ShallowCopy::shallow_copy`
+
+error[E0599]: no method named `shallow_copy` found for struct `Generic<std::cell::Cell<()>>` in the current scope
+  --> $DIR/lib.rs:24:10
+   |
+14 | struct Generic<T> {
+   | ----------------- method `shallow_copy` not found for this
+...
+24 |     generic.shallow_copy();
+   |             ^^^^^^^^^^^^ method not found in `Generic<std::cell::Cell<()>>`
+   |
+   = note: the method `shallow_copy` exists but the following trait bounds were not satisfied:
+           `Generic<std::cell::Cell<()>> : evmap::shallow_copy::ShallowCopy`
+   = help: items from traits can only be used if the trait is implemented and in scope
+   = note: the following trait defines an item `shallow_copy`, perhaps you need to implement it:
+           candidate #1: `evmap::shallow_copy::ShallowCopy`

--- a/evmap-derive/tests/lib.rs
+++ b/evmap-derive/tests/lib.rs
@@ -1,0 +1,65 @@
+use evmap::shallow_copy::ShallowCopy as _;
+use evmap_derive::ShallowCopy;
+use std::sync::Arc;
+
+#[derive(ShallowCopy)]
+enum Message {
+    Quit,
+    ChangeColor(i32, i32, i32),
+    Move { x: i32, y: i32 },
+    Write(String),
+}
+
+#[derive(ShallowCopy)]
+struct Shallow;
+
+#[derive(ShallowCopy)]
+struct Tuple(i32, String, Shallow);
+
+#[derive(ShallowCopy)]
+struct Test {
+    f1: i32,
+    f2: (i32, i32),
+    f3: String,
+    f4: Arc<String>,
+    f5: Shallow,
+    f6: evmap::shallow_copy::CopyValue<i32>,
+    f7: Tuple,
+}
+
+#[derive(ShallowCopy)]
+struct Generic<T> {
+    f1: T,
+}
+
+#[test]
+fn test() {
+    unsafe {
+        let message = Message::Quit;
+        message.shallow_copy();
+        let shallow = Shallow;
+        shallow.shallow_copy();
+        let tuple = Tuple(0, "test".to_owned(), Shallow);
+        tuple.shallow_copy();
+        let test = Test {
+            f1: 0,
+            f2: (1, 2),
+            f3: "test".to_owned(),
+            f4: Arc::new("test".to_owned()),
+            f5: shallow,
+            f6: 3.into(),
+            f7: tuple,
+        };
+        test.shallow_copy();
+        let generic = Generic {
+            f1: "test".to_owned(),
+        };
+        generic.shallow_copy();
+    }
+}
+
+#[test]
+fn failing() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/failing/lib.rs");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -249,7 +249,7 @@ pub(crate) type Epochs = Arc<Mutex<Vec<Arc<atomic::AtomicUsize>>>>;
 ///
 /// The predicate function is called once for each distinct value, and `true` if this is the
 /// _first_ call to the predicate on the _second_ application of the operation.
-pub struct Predicate<V>(pub(crate) Box<dyn FnMut(&V, bool) -> bool + Send + Sync>);
+pub struct Predicate<V>(pub(crate) Box<dyn FnMut(&V, bool) -> bool + Send>);
 
 impl<V> Predicate<V> {
     /// Evaluate the predicate for the given element

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,7 @@
 //! }
 //!
 //! // iterate over everything.
-//! for (book, reviews) in &book_reviews_r.read() {
+//! for (book, reviews) in &book_reviews_r.read().unwrap() {
 //!     for review in reviews {
 //!         println!("{}: \"{}\"", book, review);
 //!     }

--- a/src/read/guard.rs
+++ b/src/read/guard.rs
@@ -1,3 +1,4 @@
+use crate::values::{Values, ValuesIter};
 use std::mem;
 use std::sync;
 use std::sync::atomic;
@@ -62,5 +63,14 @@ impl<'rh, T: ?Sized> Drop for ReadGuard<'rh, T> {
             (self.epoch + 1) | 1usize << (mem::size_of::<usize>() * 8 - 1),
             atomic::Ordering::Release,
         );
+    }
+}
+
+impl<'rh, T, S> IntoIterator for &'rh ReadGuard<'rh, Values<T, S>> {
+    type Item = &'rh T;
+    type IntoIter = ValuesIter<'rh, T, S>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.t.into_iter()
     }
 }

--- a/src/values.rs
+++ b/src/values.rs
@@ -71,6 +71,18 @@ impl<T, S> Values<T, S> {
         }
     }
 
+    /// Returns a guarded reference to _one_ value corresponding to the key.
+    ///
+    /// This is mostly intended for use when you are working with no more than one value per key.
+    /// If there are multiple values stored for this key, there are no guarantees to which element
+    /// is returned.
+    pub fn get_one(&self) -> Option<&T> {
+        match self.0 {
+            ValuesInner::Short(ref v) => v.get(0),
+            ValuesInner::Long(ref v) => v.iter().next(),
+        }
+    }
+
     /// Returns true if a value matching `value` is among the stored values.
     ///
     /// The value may be any borrowed form of `T`, but [`Hash`] and [`Eq`] on the borrowed form

--- a/src/write.rs
+++ b/src/write.rs
@@ -471,7 +471,7 @@ where
     /// at and beyond when the second argument is true.
     pub unsafe fn retain<F>(&mut self, k: K, f: F) -> &mut Self
     where
-        F: FnMut(&V, bool) -> bool + 'static + Send + Sync,
+        F: FnMut(&V, bool) -> bool + 'static + Send,
     {
         self.add_op(Operation::Retain(k, Predicate(Box::new(f))))
     }


### PR DESCRIPTION
Hi there!

As mentioned in #47, I'm using evmap in a (soon-to-be) production project, and ended up making some changes to make evmap easier for _my personal_ use - and I figured some of them might be interesting to you as well. I am merely presenting this to you as a list of things to pick and choose from - tell me which ones you'd be interested in merging, and I'll remove the rest from this PR. Also if there are any code style/documentation/naming/other changes you'd like me to make (including splitting things up into multiple commits/PRs), just let me know!

- Added an evmap-derive proc-macro crate for ShallowCopy
- Removed the requirement for Send + Sync on `Predicate` for `reject` - it's not actually sent across threads, so there's no need for it from what I could see
- Added an IntoIterator implementation for ReadGuard (allows doing `map.get(&key).iter().flatten()`)
- Made read() return an Option instead, which allows many of the MapReadRef methods to return non-wrapped values (the way I understood it it can't be modified or destroyed while the lock is held anyway)
- Added `single` functions to the read modules - allows for simple and efficient reading of single values
- Added `contains_value` convenience function to the read modules
- Added ShallowCopy implementation for Option<T>
- Added Default derive for ShallowCopy
- Added defaults for MapReadRef type parameters M and S to make it easier in use

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jonhoo/rust-evmap/48)
<!-- Reviewable:end -->
