### PR TITLE
Re-use epoch slots when ReadHandles go away

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,4 @@ indexmap = { version = "1.1.0", optional = true }
 smallvec = "1.0.0"
 hashbag = "0.1.2"
 bytes = { version = "0.5", optional = true }
+slab = "0.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -248,7 +248,7 @@ use crate::inner::Inner;
 mod values;
 pub use values::Values;
 
-pub(crate) type Epochs = Arc<Mutex<Vec<Arc<atomic::AtomicUsize>>>>;
+pub(crate) type Epochs = Arc<Mutex<slab::Slab<Arc<atomic::AtomicUsize>>>>;
 
 /// Unary predicate used to retain elements.
 ///


### PR DESCRIPTION
Previously, when a `ReadHandle` was dropped, its epoch in the "master"
epoch list would remain. This is unfortunate if there is a lot of
`ReadHandle` churn, for two reasons. First, it causes memory use to keep
increasing over time. And second, it means that the writer has to check
an increasing number of forever unchanging epochs.

This patch moves to `slab` for the epoch store, and removes the epoch
for a `ReadHandle` when it is dropped.

This isn't _technically_ a memory leak, because the memory would be
reclaimed when the last handle was eventually dropped, but in practice
it lead to ever-growing memory use.

Fixes #53.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jonhoo/rust-evmap/54)
<!-- Reviewable:end -->
