### PR TITLE
Adds tests for get_one

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -250,12 +250,6 @@ pub use values::Values;
 
 pub(crate) type Epochs = Arc<Mutex<slab::Slab<Arc<atomic::AtomicUsize>>>>;
 
-/// This value determines when a value-set is promoted from a list to a HashBag.
-///
-/// This is only pub so it can be used in tests!
-#[doc(hidden)]
-pub const BAG_THRESHOLD: usize = 32;
-
 /// Unary predicate used to retain elements.
 ///
 /// The predicate function is called once for each distinct value, and `true` if this is the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -250,6 +250,10 @@ pub use values::Values;
 
 pub(crate) type Epochs = Arc<Mutex<slab::Slab<Arc<atomic::AtomicUsize>>>>;
 
+/// This is only pub so it can be used in tests!
+#[doc(hidden)]
+pub const BAG_THRESHOLD: usize = 32;
+
 /// Unary predicate used to retain elements.
 ///
 /// The predicate function is called once for each distinct value, and `true` if this is the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -250,6 +250,8 @@ pub use values::Values;
 
 pub(crate) type Epochs = Arc<Mutex<slab::Slab<Arc<atomic::AtomicUsize>>>>;
 
+/// This value determines when a value-set is promoted from a list to a HashBag.
+///
 /// This is only pub so it can be used in tests!
 #[doc(hidden)]
 pub const BAG_THRESHOLD: usize = 32;

--- a/src/values.rs
+++ b/src/values.rs
@@ -1,8 +1,10 @@
-use crate::BAG_THRESHOLD;
 use std::borrow::Borrow;
 use std::fmt;
 use std::hash::{BuildHasher, Hash};
 use std::mem::ManuallyDrop;
+
+/// This value determines when a value-set is promoted from a list to a HashBag.
+const BAG_THRESHOLD: usize = 32;
 
 /// A bag of values for a given key in the evmap.
 #[repr(transparent)]

--- a/src/values.rs
+++ b/src/values.rs
@@ -1,9 +1,8 @@
+use crate::BAG_THRESHOLD;
 use std::borrow::Borrow;
 use std::fmt;
 use std::hash::{BuildHasher, Hash};
 use std::mem::ManuallyDrop;
-
-const BAG_THRESHOLD: usize = 32;
 
 /// A bag of values for a given key in the evmap.
 #[repr(transparent)]

--- a/src/values.rs
+++ b/src/values.rs
@@ -319,8 +319,8 @@ mod tests {
 
     macro_rules! assert_empty {
         ($x:expr) => {
-            assert!($x.is_empty());
             assert_eq!($x.len(), 0);
+            assert!($x.is_empty());
             assert_eq!($x.iter().count(), 0);
             assert_eq!($x.into_iter().count(), 0);
             assert_eq!($x.get_one(), None);
@@ -329,8 +329,8 @@ mod tests {
 
     macro_rules! assert_len {
         ($x:expr, $n:expr) => {
-            assert!(!$x.is_empty());
             assert_eq!($x.len(), $n);
+            assert!(!$x.is_empty());
             assert_eq!($x.iter().count(), $n);
             assert_eq!($x.into_iter().count(), $n);
         };

--- a/src/values.rs
+++ b/src/values.rs
@@ -100,6 +100,11 @@ impl<T, S> Values<T, S> {
             ValuesInner::Long(ref v) => v.contains(value) != 0,
         }
     }
+
+    #[cfg(test)]
+    fn is_short(&self) -> bool {
+        matches!(self.0, ValuesInner::Short(_))
+    }
 }
 
 impl<'a, T, S> IntoIterator for &'a Values<T, S> {
@@ -331,20 +336,10 @@ mod tests {
         };
     }
 
-    fn has_short_values<T, S>(v: &Values<T, S>) -> bool {
-        match v.0 {
-            ValuesInner::Short(_) => true,
-            _ => false,
-        }
-    }
-    fn has_long_values<T, S>(v: &Values<T, S>) -> bool {
-        !has_short_values(v)
-    }
-
     #[test]
     fn sensible_default() {
         let v: Values<i32> = Values::default();
-        assert!(has_short_values(&v));
+        assert!(v.is_short());
         assert_eq!(v.capacity(), 1);
         assert_empty!(v);
     }
@@ -363,7 +358,7 @@ mod tests {
         for i in values.clone() {
             assert!(v.contains(&i));
         }
-        assert!(has_short_values(&v));
+        assert!(v.is_short());
         assert_len!(v, len);
         assert_eq!(v.get_one(), Some(&0));
 
@@ -373,7 +368,7 @@ mod tests {
 
         // clear() should not affect capacity or value type!
         assert!(v.capacity() > 1);
-        assert!(has_short_values(&v));
+        assert!(v.is_short());
 
         v.shrink_to_fit();
 
@@ -394,7 +389,7 @@ mod tests {
         for i in values.clone() {
             assert!(v.contains(&i));
         }
-        assert!(has_long_values(&v));
+        assert!(!v.is_short());
         assert_len!(v, len);
         assert!(values.contains(v.get_one().unwrap()));
 
@@ -404,12 +399,12 @@ mod tests {
 
         // clear() should not affect capacity or value type!
         assert!(v.capacity() > 1);
-        assert!(has_long_values(&v));
+        assert!(!v.is_short());
 
         v.shrink_to_fit();
 
         // Now we have short values!
-        assert!(has_short_values(&v));
+        assert!(v.is_short());
         assert_eq!(v.capacity(), 1);
     }
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -750,7 +750,7 @@ fn get_one_short() {
 
 #[test]
 fn get_one_long() {
-    let x = ('x', 42);
+    let x = 'x';
 
     let (r, mut w) = evmap::new();
 
@@ -758,14 +758,14 @@ fn get_one_long() {
     // ensure the inner type is ValuesInner::Long.
     let values = 0..32;
     for i in values.clone() {
-        w.insert(x.0, i);
+        w.insert(x, i);
     }
 
-    assert_match!(r.get_one(&x.0), None);
+    assert_match!(r.get_one(&x), None);
 
     w.refresh();
 
     // We don't know exactly which value we're going to get but
     // it better be one of the values we inserted.
-    assert!(values.contains(r.get_one(&x.0).unwrap().as_ref()));
+    assert!(values.contains(r.get_one(&x).unwrap().as_ref()));
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -734,11 +734,12 @@ fn retain() {
 }
 
 #[test]
-fn get_one_short() {
+fn get_one() {
     let x = ('x', 42);
 
     let (r, mut w) = evmap::new();
 
+    w.insert(x.0, x);
     w.insert(x.0, x);
 
     assert_match!(r.get_one(&x.0), None);
@@ -746,25 +747,4 @@ fn get_one_short() {
     w.refresh();
 
     assert_match!(r.get_one(&x.0).as_deref(), Some(('x', 42)));
-}
-
-#[test]
-fn get_one_long() {
-    let x = 'x';
-
-    let (r, mut w) = evmap::new();
-
-    // Add BAG_THRESHOLD items to ensure the inner type is ValuesInner::Long.
-    let values = 0..evmap::BAG_THRESHOLD;
-    for i in values.clone() {
-        w.insert(x, i);
-    }
-
-    assert_match!(r.get_one(&x), None);
-
-    w.refresh();
-
-    // We don't know exactly which value we're going to get but
-    // it better be one of the values we inserted.
-    assert!(values.contains(r.get_one(&x).unwrap().as_ref()));
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -732,3 +732,40 @@ fn retain() {
     vs.sort();
     assert_eq!(v, &*vs);
 }
+
+#[test]
+fn get_one_short() {
+    let x = ('x', 42);
+
+    let (r, mut w) = evmap::new();
+
+    w.insert(x.0, x);
+
+    assert_match!(r.get_one(&x.0), None);
+
+    w.refresh();
+
+    assert_match!(r.get_one(&x.0).unwrap().as_ref(), ('x', 42));
+}
+
+#[test]
+fn get_one_long() {
+    let x = ('x', 42);
+
+    let (r, mut w) = evmap::new();
+
+    // Add 32 items to meet the BAG_THRESHOLD and
+    // ensure the inner type is ValuesInner::Long.
+    let values = 0..32;
+    for i in values.clone() {
+        w.insert(x.0, i);
+    }
+
+    assert_match!(r.get_one(&x.0), None);
+
+    w.refresh();
+
+    // We don't know exactly which value we're going to get but
+    // it better be one of the values we inserted.
+    assert!(values.contains(r.get_one(&x.0).unwrap().as_ref()));
+}

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -754,9 +754,8 @@ fn get_one_long() {
 
     let (r, mut w) = evmap::new();
 
-    // Add 32 items to meet the BAG_THRESHOLD and
-    // ensure the inner type is ValuesInner::Long.
-    let values = 0..32;
+    // Add BAG_THRESHOLD items to ensure the inner type is ValuesInner::Long.
+    let values = 0..evmap::BAG_THRESHOLD;
     for i in values.clone() {
         w.insert(x, i);
     }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -745,7 +745,7 @@ fn get_one_short() {
 
     w.refresh();
 
-    assert_match!(r.get_one(&x.0).unwrap().as_ref(), ('x', 42));
+    assert_match!(r.get_one(&x.0).as_deref(), Some(('x', 42)));
 }
 
 #[test]


### PR DESCRIPTION
**This PR**
Attempting to help along with https://github.com/jonhoo/rust-evmap/issues/31.

**Notes**
It appeared that [`get_one`](https://codecov.io/gh/jonhoo/rust-evmap/src/master/src/read/mod.rs#L291) wasn't tested. I'm not sure if these tests are in the right place or if they should live in `read/mod`. Or maybe this isn't tested because it's not valuable functionality? 🤷

I tried to handle both inner cases - `ValuesInner::Short` and `ValuesInner::Long`. I'm not 100% sure it's necessary to test `ValuesInner::Long` because, although it's supported, it's clearly documented that, in the case of multiple values, the exact return value is not guaranteed. So it's nice to make sure it doesn't explode with multiple values but it also doesn't feel particularly useful asserting any particular returned value. I also feel pretty badly about the magic number with no hard-reference to `BAG_THRESHOLD`. ~If we do want to improve the readability there, it looked like there was a `with_capacity` on `Options` but I didn't see one for `evmap` so I wasn't sure how to do that idiomatically. I probably read the docs wrong.~ It looks like you can do something like:
```rust
Options::default().with_capacity(BAG_THRESHOLD).construct()
```
although maybe there's a slightly more compact method.

~Finally, I don't know how to check code coverage before merging this so acknowledging that there's no guarantee the coverage will increase, I'm fine with just chucking this PR (but would still like to help if any more specific guidance is available!).~ Looks like it shows up right there in the PR! Neat!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jonhoo/rust-evmap/56)
<!-- Reviewable:end -->
