### PR TITLE
Improve naming of remove methods

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -285,15 +285,15 @@ impl<V> fmt::Debug for Predicate<V> {
 /// A pending map operation.
 #[non_exhaustive]
 #[derive(PartialEq, Eq, Debug)]
-pub enum Operation<K, V> {
+pub(crate) enum Operation<K, V> {
     /// Replace the set of entries for this key with this value.
     Replace(K, V),
     /// Add this value to the set of entries for this key.
     Add(K, V),
     /// Remove this value from the set of entries for this key.
-    Remove(K, V),
+    RemoveValue(K, V),
     /// Remove the value set for this key.
-    Empty(K),
+    RemoveEntry(K),
     #[cfg(feature = "eviction")]
     /// Drop keys at the given indices.
     ///

--- a/src/write.rs
+++ b/src/write.rs
@@ -336,38 +336,12 @@ where
         self
     }
 
-    /// Gives the sequence of operations that have not yet been applied.
-    ///
-    /// Note that until the *first* call to `refresh`, the sequence of operations is always empty.
-    ///
-    /// ```
-    /// # use evmap::Operation;
-    /// let x = ('x', 42);
-    ///
-    /// let (r, mut w) = evmap::new();
-    ///
-    /// // before the first refresh, no oplog is kept
-    /// w.refresh();
-    ///
-    /// assert_eq!(w.pending(), &[]);
-    /// w.insert(x.0, x);
-    /// assert_eq!(w.pending(), &[Operation::Add(x.0, x)]);
-    /// w.refresh();
-    /// w.remove(x.0, x);
-    /// assert_eq!(w.pending(), &[Operation::Remove(x.0, x)]);
-    /// w.refresh();
-    /// assert_eq!(w.pending(), &[]);
-    /// ```
-    pub fn pending(&self) -> &[Operation<K, V>] {
-        &self.oplog[self.swap_index..]
-    }
-
     /// Refresh as necessary to ensure that all operations are visible to readers.
     ///
     /// `WriteHandle::refresh` will *always* wait for old readers to depart and swap the maps.
     /// This method will only do so if there are pending operations.
     pub fn flush(&mut self) -> &mut Self {
-        if !self.pending().is_empty() {
+        if !self.oplog[self.swap_index..].is_empty() {
             self.refresh();
         }
 
@@ -440,7 +414,7 @@ where
     ///
     /// The updated value-bag will only be visible to readers after the next call to `refresh()`.
     pub fn remove_value(&mut self, k: K, v: V) -> &mut Self {
-        self.add_op(Operation::Remove(k, v))
+        self.add_op(Operation::RemoveValue(k, v))
     }
 
     /// Remove the value-bag for the given key.
@@ -455,7 +429,7 @@ where
     ///
     /// The value-bag will only disappear from readers after the next call to `refresh()`.
     pub fn remove_entry(&mut self, k: K) -> &mut Self {
-        self.add_op(Operation::Empty(k))
+        self.add_op(Operation::RemoveEntry(k))
     }
 
     /// Purge all value-bags from the map.
@@ -593,7 +567,7 @@ where
                     .or_insert_with(Values::new)
                     .push(unsafe { value.shallow_copy() }, hasher);
             }
-            Operation::Empty(ref key) => {
+            Operation::RemoveEntry(ref key) => {
                 #[cfg(not(feature = "indexed"))]
                 inner.data.remove(key);
                 #[cfg(feature = "indexed")]
@@ -608,7 +582,7 @@ where
                     inner.data.swap_remove_index(index);
                 }
             }
-            Operation::Remove(ref key, ref value) => {
+            Operation::RemoveValue(ref key, ref value) => {
                 if let Some(e) = inner.data.get_mut(key) {
                     // remove a matching value from the value set
                     // safety: this is fine
@@ -671,7 +645,7 @@ where
                     .or_insert_with(Values::new)
                     .push(value, hasher);
             }
-            Operation::Empty(key) => {
+            Operation::RemoveEntry(key) => {
                 #[cfg(not(feature = "indexed"))]
                 inner.data.remove(&key);
                 #[cfg(feature = "indexed")]
@@ -686,7 +660,7 @@ where
                     inner.data.swap_remove_index(index);
                 }
             }
-            Operation::Remove(key, value) => {
+            Operation::RemoveValue(key, value) => {
                 if let Some(e) = inner.data.get_mut(&key) {
                     // find the first entry that matches all fields
                     e.swap_remove(&value);
@@ -752,5 +726,26 @@ where
     type Target = ReadHandle<K, V, M, S>;
     fn deref(&self) -> &Self::Target {
         &self.r_handle
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::new;
+
+    #[test]
+    fn flush_noblock() {
+        let x = ('x', 42);
+
+        let (r, mut w) = new();
+        w.insert(x.0, x);
+        w.refresh();
+        assert_eq!(r.get(&x.0).map(|rs| rs.len()), Some(1));
+
+        // pin the epoch
+        let _map = r.read();
+        // refresh would hang here, but flush won't
+        assert!(w.oplog[w.swap_index..].is_empty());
+        w.flush();
     }
 }

--- a/src/write.rs
+++ b/src/write.rs
@@ -341,7 +341,7 @@ where
     /// `WriteHandle::refresh` will *always* wait for old readers to depart and swap the maps.
     /// This method will only do so if there are pending operations.
     pub fn flush(&mut self) -> &mut Self {
-        if !self.oplog[self.swap_index..].is_empty() {
+        if self.swap_index < self.oplog.len() {
             self.refresh();
         }
 

--- a/src/write.rs
+++ b/src/write.rs
@@ -431,14 +431,30 @@ where
     /// Remove the given value from the value-bag of the given key.
     ///
     /// The updated value-bag will only be visible to readers after the next call to `refresh()`.
+    #[deprecated(since = "11.0.0", note = "Renamed to remove_value")]
     pub fn remove(&mut self, k: K, v: V) -> &mut Self {
+        self.remove_value(k, v)
+    }
+
+    /// Remove the given value from the value-bag of the given key.
+    ///
+    /// The updated value-bag will only be visible to readers after the next call to `refresh()`.
+    pub fn remove_value(&mut self, k: K, v: V) -> &mut Self {
         self.add_op(Operation::Remove(k, v))
     }
 
     /// Remove the value-bag for the given key.
     ///
     /// The value-bag will only disappear from readers after the next call to `refresh()`.
+    #[deprecated(since = "11.0.0", note = "Renamed to remove_entry")]
     pub fn empty(&mut self, k: K) -> &mut Self {
+        self.remove_entry(k)
+    }
+
+    /// Remove the value-bag for the given key.
+    ///
+    /// The value-bag will only disappear from readers after the next call to `refresh()`.
+    pub fn remove_entry(&mut self, k: K) -> &mut Self {
         self.add_op(Operation::Empty(k))
     }
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -350,14 +350,14 @@ fn clear_vs_empty() {
     w.clear(1);
     w.refresh();
     assert_eq!(r.get(&1).map(|rs| rs.len()), Some(0));
-    w.empty(1);
+    w.remove_entry(1);
     w.refresh();
     assert_eq!(r.get(&1).map(|rs| rs.len()), None);
     // and again to test both apply_first and apply_second
     w.clear(1);
     w.refresh();
     assert_eq!(r.get(&1).map(|rs| rs.len()), Some(0));
-    w.empty(1);
+    w.remove_entry(1);
     w.refresh();
     assert_eq!(r.get(&1).map(|rs| rs.len()), None);
 }
@@ -391,7 +391,7 @@ fn absorb_negative_immediate() {
     let (r, mut w) = evmap::new();
     w.insert(1, "a");
     w.insert(1, "b");
-    w.remove(1, "a");
+    w.remove_value(1, "a");
     w.refresh();
 
     assert_eq!(r.get(&1).map(|rs| rs.len()), Some(1));
@@ -404,7 +404,7 @@ fn absorb_negative_later() {
     w.insert(1, "a");
     w.insert(1, "b");
     w.refresh();
-    w.remove(1, "a");
+    w.remove_value(1, "a");
     w.refresh();
 
     assert_eq!(r.get(&1).map(|rs| rs.len()), Some(1));
@@ -421,9 +421,9 @@ fn absorb_multi() {
     assert!(r.get(&1).map(|rs| rs.iter().any(|r| r == &"a")).unwrap());
     assert!(r.get(&1).map(|rs| rs.iter().any(|r| r == &"b")).unwrap());
 
-    w.remove(1, "a");
+    w.remove_value(1, "a");
     w.insert(1, "c");
-    w.remove(1, "c");
+    w.remove_value(1, "c");
     w.refresh();
 
     assert_eq!(r.get(&1).map(|rs| rs.len()), Some(1));
@@ -436,7 +436,7 @@ fn empty() {
     w.insert(1, "a");
     w.insert(1, "b");
     w.insert(2, "c");
-    w.empty(1);
+    w.remove_entry(1);
     w.refresh();
 
     assert_eq!(r.get(&1).map(|rs| rs.len()), None);
@@ -499,7 +499,7 @@ fn empty_post_refresh() {
     w.insert(1, "b");
     w.insert(2, "c");
     w.refresh();
-    w.empty(1);
+    w.remove_entry(1);
     w.refresh();
 
     assert_eq!(r.get(&1).map(|rs| rs.len()), None);
@@ -525,7 +525,7 @@ fn clear() {
     assert_eq!(r.get(&1).map(|rs| rs.len()), Some(0));
     assert_eq!(r.get(&2).map(|rs| rs.len()), Some(0));
 
-    w.empty(1);
+    w.remove_entry(1);
     w.refresh();
 
     assert_eq!(r.get(&1).map(|rs| rs.len()), None);
@@ -668,12 +668,12 @@ fn bigbag() {
         }
         for i in (1..ndistinct).rev() {
             for _ in 0..i {
-                w.remove(1, vec![i]);
+                w.remove_value(1, vec![i]);
                 w.fit(1);
                 w.refresh();
             }
         }
-        w.empty(1);
+        w.remove_entry(1);
     }
 
     drop(w);
@@ -750,14 +750,14 @@ fn get_one() {
 }
 
 #[test]
-fn insert_remove() {
+fn insert_remove_value() {
     let x = 'x';
 
     let (r, mut w) = evmap::new();
 
     w.insert(x, x);
 
-    w.remove(x, x);
+    w.remove_value(x, x);
     w.refresh();
 
     // There are no more values associated with this key
@@ -770,14 +770,14 @@ fn insert_remove() {
 }
 
 #[test]
-fn insert_empty() {
+fn insert_remove_entry() {
     let x = 'x';
 
     let (r, mut w) = evmap::new();
 
     w.insert(x, x);
 
-    w.empty(x);
+    w.remove_entry(x);
     w.refresh();
 
     assert!(r.is_empty());

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -174,22 +174,6 @@ fn paniced_reader_doesnt_block_writer() {
 }
 
 #[test]
-fn flush_noblock() {
-    let x = ('x', 42);
-
-    let (r, mut w) = evmap::new();
-    w.insert(x.0, x);
-    w.refresh();
-    assert_eq!(r.get(&x.0).map(|rs| rs.len()), Some(1));
-
-    // pin the epoch
-    let _map = r.read();
-    // refresh would hang here, but flush won't
-    assert!(w.pending().is_empty());
-    w.flush();
-}
-
-#[test]
 fn read_after_drop() {
     let x = ('x', 42);
 

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -57,7 +57,7 @@ fn insert_empty(insert: Vec<u8>, remove: Vec<u8>) -> bool {
     }
     w.refresh();
     for &key in &remove {
-        w.empty(key);
+        w.remove_entry(key);
     }
     w.refresh();
     let elements = &set(&insert) - &set(&remove);
@@ -110,11 +110,11 @@ fn do_ops<K, V, S>(
                     .push(v.clone());
             }
             Remove(ref k) => {
-                evmap.empty(k.clone());
+                evmap.remove_entry(k.clone());
                 write_ref.remove(k);
             }
             RemoveValue(ref k, ref v) => {
-                evmap.remove(k.clone(), v.clone());
+                evmap.remove_value(k.clone(), v.clone());
                 write_ref.get_mut(k).and_then(|values| {
                     values
                         .iter_mut()

--- a/tests/quick.rs
+++ b/tests/quick.rs
@@ -119,7 +119,7 @@ fn do_ops<K, V, S>(
                     values
                         .iter_mut()
                         .position(|value| value == v)
-                        .and_then(|pos| Some(values.remove(pos)))
+                        .and_then(|pos| Some(values.swap_remove(pos)))
                 });
             }
             Refresh => {


### PR DESCRIPTION
**This PR**
- Deprecates the `remove` method for a more descriptive method `remove_value`
- Deprecates the `empty` method for a more description method `remove_empty`
- Uses `swap_remove` in a test where the order doesn't matter so why not

**Why?**
Using the standard lib as a North Star, [`remove`](https://doc.rust-lang.org/beta/std/collections/struct.HashMap.html#method.remove) should be a method that takes a key and removes that key from the map. In `evmap`, `remove` is meant to take a key _and a value_ and remove _just that value_ from the value bag for the key. To make that more clear, we deprecate `remove` and rename it to `remove_value`.

Unfortunately we can't then rename `empty` (`evmap`'s version of the std `HashMap`s `remove`) to `remove` for backwards compatibility. Instead, we rename it to `remove_entry`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jonhoo/rust-evmap/59)
<!-- Reviewable:end -->
