### PR TITLE
Removes use of deprecated method in example

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,8 +63,8 @@
 //! assert_eq!(book_reviews_r.get("Grimms' Fairy Tales").map(|rs| rs.len()), Some(2));
 //!
 //! // oops, this review has a lot of spelling mistakes, let's delete it.
-//! // empty deletes *all* reviews (though in this case, just one)
-//! book_reviews_w.empty("The Adventures of Sherlock Holmes");
+//! // remove_entry deletes *all* reviews (though in this case, just one)
+//! book_reviews_w.remove_entry("The Adventures of Sherlock Holmes");
 //! // but again, it's not visible to readers until we refresh
 //! assert_eq!(book_reviews_r.get("The Adventures of Sherlock Holmes").map(|rs| rs.len()), Some(1));
 //! book_reviews_w.refresh();


### PR DESCRIPTION
When I was working on adding the `loom` tests (for https://github.com/jonhoo/rust-evmap/pull/62) I was seeing:
```
---- src/lib.rs -  (line 35) stdout ----
warning: use of deprecated item 'evmap::WriteHandle::<K, V, M, S>::empty': Renamed to remove_entry
  --> src/lib.rs:68:16
   |
36 | book_reviews_w.empty("The Adventures of Sherlock Holmes");
   |                ^^^^^
   |
   = note: `#[warn(deprecated)]` on by default
```

I don't see it normally when I `cargo check --examples` so I'd love to figure that out ... but in the meantime, this updates the one obvious example from #59

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jonhoo/rust-evmap/64)
<!-- Reviewable:end -->
