### PR TITLE
Upgrade to Bytes 0.0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ eviction = ["indexed", "rand"]
 indexmap = { version = "1.1.0", optional = true }
 smallvec = "1.0.0"
 hashbag = "0.1.2"
-bytes = { version = "0.5", optional = true }
+bytes = { version = "0.6", optional = true }
 rand = { version = "0.7", default-features = false, features = ["alloc"], optional = true }
 slab = "0.4"
 


### PR DESCRIPTION
Quick update for evmap to use latest version of bytes

`cargo test` makes this look simple enough

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jonhoo/rust-evmap/72)
<!-- Reviewable:end -->
