### PR TITLE
Move direct_write into left_right, plus a few convenience changes.

### DIFF
--- a/left-right/src/read.rs
+++ b/left-right/src/read.rs
@@ -198,7 +198,9 @@ impl<T> ReadHandle<T> {
     /// Note that it is only safe to read through this pointer if you _know_ that the writer will
     /// not start writing into it. This is most likely only the case if you are calling this method
     /// from inside a method that holds `&mut WriteHandle`.
-    pub fn raw_handle(&mut self) -> Option<NonNull<T>> {
+    ///
+    /// Casting this pointer to `&mut` is never safe.
+    pub fn raw_handle(&self) -> Option<NonNull<T>> {
         NonNull::new(self.inner.load(atomic::Ordering::Acquire))
     }
 }


### PR DESCRIPTION
I've been experimenting with using `left_right` in my production application, and there were a few changes I'd like to see to make it more convenient in usage. Generally though, the recent changes are awesome and should eliminate the need for me to fork entirely, so thank you. 💜 

This pull request:
- Moves the `direct_write` functionality into `left_right`. For this purpose, it adds a `clone_first` method to `Absorb`. I figure pretty much every implementation of `left_right` could benefit from this optimization.
- Makes `raw_handle` take `&self` rather than `&mut self`. It doesn't need it, and it was getting in the way (more on that later).
- Re-adds the `flush` method that only `publish`es if there are actually oplog entries. Cause convenience.
- Makes `left_right::new` not require `Clone`. Duplicates a little bit of code, but again, convenience.

This is a draft pull request because:
- All the unit tests run through fine, but I haven't actually tested it in production yet.
- I'd like your feedback on which of these you actually want to incorporate.
- I haven't fully updated documentation (will do once the previous point is settled.)
- I'm not sure whether the change to `raw_handle` is actually correct - the doc says "it is only safe to read through this pointer if you _know_ that the writer will not start writing into it," and I'm understanding that as "there may not be a _publish_ while the pointer is being held," but if even calling `add_op` may cause issues, then this change is probably incorrect.
- I'm also not sure how correct [this](https://github.com/MayaWolf/rust-evmap/blob/645f1b213c23c83cd9db3041ef50ccb2a778bf2d/evmap/src/write.rs#L556) is. In fact, I'm not quite sure what the purpose of the `ready` flag is - I figure it's to prevent read access to a map that hasn't seen a publish yet, but I'm also not sure what the problem with that would be. There's probably something I'm missing here.

One more thing that's more of a question, but it might be something that can be fixed in `Aliased`:
Is there any way to get `as_deref` to work with an `Option<&Aliased<T, D>>`? Right now, it seems to just...do nothing, and I'm not sure why.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jonhoo/rust-evmap/84)
<!-- Reviewable:end -->
