### PR TITLE
Add an accumulator type to the Absorb trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,7 +61,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "left-right"
-version = "0.11.7"
+version = "0.12.0"
 dependencies = [
  "crossbeam-utils",
  "loom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "left-right"
-version = "0.11.7"
+version = "0.12.0"
 authors = ["Jon Gjengset <jon@thesquareplanet.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,11 +75,13 @@
 //! // and provide the oplog type as the generic argument.
 //! // You can read this as "`i32` can absorb changes of type `CounterAddOp`".
 //! impl Absorb<CounterAddOp> for i32 {
+//!     type Accumulator = ();
+//!
 //!     // See the documentation of `Absorb::absorb_first`.
 //!     //
 //!     // Essentially, this is where you define what applying
 //!     // the oplog type to the datastructure does.
-//!     fn absorb_first(&mut self, operation: &mut CounterAddOp, _: &Self) {
+//!     fn absorb_first(&mut self, operation: &mut CounterAddOp, _: &Self, _acc: &mut ()) {
 //!         *self += operation.0;
 //!     }
 //!
@@ -88,7 +90,7 @@
 //!     // This may or may not be the same as `absorb_first`,
 //!     // depending on whether or not you de-duplicate values
 //!     // across the two copies of your data structure.
-//!     fn absorb_second(&mut self, operation: CounterAddOp, _: &Self) {
+//!     fn absorb_second(&mut self, operation: CounterAddOp, _: &Self, _acc: &mut ()) {
 //!         *self += operation.0;
 //!     }
 //!
@@ -215,12 +217,31 @@ pub mod aliasing;
 /// values rather than drop them so that they are not dropped twice when the second copy is
 /// dropped.
 pub trait Absorb<O> {
+    /// An accumulator type built up across all absorb calls in a single loop.
+    ///
+    /// Before each absorb loop a value of this type is created via [`Default::default`] and passed
+    /// by mutable reference to every [`absorb_first`](Self::absorb_first) /
+    /// [`absorb_second`](Self::absorb_second) call. After the loop completes,
+    /// [`finalize_absorb`](Self::finalize_absorb) is called once with the accumulated value.
+    ///
+    /// Set this to `()` (and leave [`finalize_absorb`](Self::finalize_absorb) as the default
+    /// no-op) if you do not need batch finalization.
+    type Accumulator: Default;
+
     /// Apply `O` to the first of the two copies.
     ///
     /// `other` is a reference to the other copy of the data, which has seen all operations up
     /// until the previous call to [`WriteHandle::publish`]. That is, `other` is one "publish
     /// cycle" behind.
-    fn absorb_first(&mut self, operation: &mut O, other: &Self);
+    ///
+    /// `accumulator` is shared across all calls in the same absorb loop and will be passed to
+    /// [`finalize_absorb`](Self::finalize_absorb) after the loop ends.
+    fn absorb_first(
+        &mut self,
+        operation: &mut O,
+        other: &Self,
+        accumulator: &mut Self::Accumulator,
+    );
 
     /// Apply `O` to the second of the two copies.
     ///
@@ -234,10 +255,27 @@ pub trait Absorb<O> {
     /// (like `Eq` and `Hash`), and of "hidden states" that subtly affect results like the
     /// `RandomState` of a `HashMap` which can change iteration order.
     ///
+    /// `accumulator` is shared across all calls in the same absorb loop and will be passed to
+    /// [`finalize_absorb`](Self::finalize_absorb) after the loop ends.
+    ///
     /// Defaults to calling `absorb_first`.
-    fn absorb_second(&mut self, mut operation: O, other: &Self) {
-        Self::absorb_first(self, &mut operation, other)
+    fn absorb_second(
+        &mut self,
+        mut operation: O,
+        other: &Self,
+        accumulator: &mut Self::Accumulator,
+    ) {
+        Self::absorb_first(self, &mut operation, other, accumulator)
     }
+
+    /// Called once after all [`absorb_first`](Self::absorb_first) or
+    /// [`absorb_second`](Self::absorb_second) calls in a loop complete.
+    ///
+    /// Use this to perform an aggregate computation that is more efficient to do once over all
+    /// absorbed operations rather than incrementally after each individual call.
+    ///
+    /// Defaults to a no-op.
+    fn finalize_absorb(&mut self, _accumulator: Self::Accumulator, _other: &Self) {}
 
     /// Drop the first of the two copies.
     ///

--- a/src/utilities.rs
+++ b/src/utilities.rs
@@ -4,11 +4,13 @@ pub struct CounterAddOp(pub i32);
 
 #[cfg(test)]
 impl Absorb<CounterAddOp> for i32 {
-    fn absorb_first(&mut self, operation: &mut CounterAddOp, _: &Self) {
+    type Accumulator = ();
+
+    fn absorb_first(&mut self, operation: &mut CounterAddOp, _: &Self, _acc: &mut ()) {
         *self += operation.0;
     }
 
-    fn absorb_second(&mut self, operation: CounterAddOp, _: &Self) {
+    fn absorb_second(&mut self, operation: CounterAddOp, _: &Self, _acc: &mut ()) {
         *self += operation.0;
     }
 

--- a/src/write.rs
+++ b/src/write.rs
@@ -389,15 +389,19 @@ where
                 // we can drain out the operations that only the w_handle copy needs
                 //
                 // NOTE: the if above is because drain(0..0) would remove 0
+                let mut acc = <T as Absorb<O>>::Accumulator::default();
                 for op in self.oplog.drain(0..self.swap_index) {
-                    T::absorb_second(w_handle, op, r_handle);
+                    T::absorb_second(w_handle, op, r_handle, &mut acc);
                 }
+                T::finalize_absorb(w_handle, acc, r_handle);
             }
             // we cannot give owned operations to absorb_first
             // since they'll also be needed by the r_handle copy
+            let mut acc = <T as Absorb<O>>::Accumulator::default();
             for op in self.oplog.iter_mut() {
-                T::absorb_first(w_handle, op, r_handle);
+                T::absorb_first(w_handle, op, r_handle, &mut acc);
             }
+            T::finalize_absorb(w_handle, acc, r_handle);
             // the w_handle copy is about to become the r_handle, and can ignore the oplog
             self.swap_index = self.oplog.len();
 
@@ -524,9 +528,11 @@ where
             let r_handle = self.enter().expect("map has not yet been destroyed");
             // Because we are operating directly on the map, and nothing is aliased, we do want
             // to perform drops, so we invoke absorb_second.
+            let mut acc = <T as Absorb<O>>::Accumulator::default();
             for op in ops {
-                Absorb::absorb_second(w_inner, op, &*r_handle);
+                Absorb::absorb_second(w_inner, op, &*r_handle, &mut acc);
             }
+            T::finalize_absorb(w_inner, acc, &*r_handle);
         } else {
             self.oplog.extend(ops);
         }
@@ -540,7 +546,8 @@ where
 ///
 /// struct Data;
 /// impl left_right::Absorb<()> for Data {
-///     fn absorb_first(&mut self, _: &mut (), _: &Self) {}
+///     type Accumulator = ();
+///     fn absorb_first(&mut self, _: &mut (), _: &Self, _: &mut ()) {}
 ///     fn sync_with(&mut self, _: &Self) {}
 /// }
 ///
@@ -560,7 +567,9 @@ where
 ///
 /// struct Data(Rc<()>);
 /// impl left_right::Absorb<()> for Data {
-///     fn absorb_first(&mut self, _: &mut (), _: &Self) {}
+///     type Accumulator = ();
+///     fn absorb_first(&mut self, _: &mut (), _: &Self, _: &mut ()) {}
+///     fn sync_with(&mut self, _: &Self) {}
 /// }
 ///
 /// fn is_send<T: Send>() {
@@ -578,7 +587,9 @@ where
 ///
 /// struct Data;
 /// impl left_right::Absorb<Rc<()>> for Data {
-///     fn absorb_first(&mut self, _: &mut Rc<()>, _: &Self) {}
+///     type Accumulator = ();
+///     fn absorb_first(&mut self, _: &mut Rc<()>, _: &Self, _: &mut ()) {}
+///     fn sync_with(&mut self, _: &Self) {}
 /// }
 ///
 /// fn is_send<T: Send>() {
@@ -596,7 +607,9 @@ where
 ///
 /// struct Data(Cell<()>);
 /// impl left_right::Absorb<()> for Data {
-///     fn absorb_first(&mut self, _: &mut (), _: &Self) {}
+///     type Accumulator = ();
+///     fn absorb_first(&mut self, _: &mut (), _: &Self, _: &mut ()) {}
+///     fn sync_with(&mut self, _: &Self) {}
 /// }
 ///
 /// fn is_send<T: Send>() {
@@ -789,5 +802,93 @@ mod tests {
         let before = w.refreshes;
         assert_eq!(w.try_publish(), true);
         assert_eq!(w.refreshes, before + 1);
+    }
+
+    // A data structure that records which ops were accumulated per finalize call.
+    #[derive(Clone, Default)]
+    struct Accumulating {
+        value: i32,
+        // ops seen per finalize_absorb invocation, in order
+        finalize_batches: Vec<Vec<i32>>,
+    }
+
+    struct AddOp(i32);
+
+    impl Absorb<AddOp> for Accumulating {
+        type Accumulator = Vec<i32>;
+
+        fn absorb_first(&mut self, op: &mut AddOp, _: &Self, acc: &mut Vec<i32>) {
+            self.value += op.0;
+            acc.push(op.0);
+        }
+
+        fn absorb_second(&mut self, op: AddOp, _: &Self, acc: &mut Vec<i32>) {
+            self.value += op.0;
+            acc.push(op.0);
+        }
+
+        fn finalize_absorb(&mut self, acc: Vec<i32>, _: &Self) {
+            self.finalize_batches.push(acc);
+        }
+
+        fn sync_with(&mut self, first: &Self) {
+            self.value = first.value;
+            self.finalize_batches = first.finalize_batches.clone();
+        }
+    }
+
+    // Before the first publish, `extend` with multiple ops calls finalize_absorb once with
+    // all ops collected into a single batch.
+    #[test]
+    fn accumulator_extend_path() {
+        let (mut w, r) = crate::new::<Accumulating, AddOp>();
+
+        // first==true: extend applies directly to the write copy via absorb_second.
+        // One finalize_absorb call with all three ops in one accumulator.
+        w.extend([AddOp(3), AddOp(5), AddOp(7)]);
+        w.publish(); // first publish: swaps copies, no absorb loops
+
+        let data = r.enter().unwrap();
+        assert_eq!(data.value, 15);
+        assert_eq!(data.finalize_batches, vec![vec![3, 5, 7]]);
+    }
+
+    // After the first publish, appended ops enter the oplog. The next publish runs the
+    // absorb_first loop, which calls finalize_absorb once with all pending ops.
+    #[test]
+    fn accumulator_absorb_first_loop() {
+        let (mut w, r) = crate::new::<Accumulating, AddOp>();
+
+        w.publish(); // first publish: exits first==true mode, no absorb loops
+        w.append(AddOp(3));
+        w.append(AddOp(5));
+        w.append(AddOp(7));
+        w.publish(); // second publish: absorb_first loop over [3, 5, 7]
+
+        let data = r.enter().unwrap();
+        assert_eq!(data.value, 15);
+        assert_eq!(data.finalize_batches, vec![vec![3, 5, 7]]);
+    }
+
+    // A third publish exercises both the absorb_second drain loop (ops from the previous
+    // publish cycle that the new write copy hasn't seen) and the absorb_first loop (ops
+    // appended since). Each loop produces its own finalize_absorb call.
+    #[test]
+    fn accumulator_absorb_second_loop() {
+        let (mut w, r) = crate::new::<Accumulating, AddOp>();
+
+        w.publish(); // exit first==true mode
+        w.append(AddOp(3));
+        w.append(AddOp(5));
+        w.append(AddOp(7));
+        w.publish(); // absorb_first loop over [3, 5, 7]; swap_index becomes 3
+
+        w.append(AddOp(10));
+        w.append(AddOp(20));
+        w.publish(); // absorb_second loop over [3,5,7] then absorb_first loop over [10,20]
+
+        let data = r.enter().unwrap();
+        assert_eq!(data.value, 45);
+        assert_eq!(data.finalize_batches, vec![vec![3, 5, 7], vec![10, 20]]);
     }
 }

--- a/tests/deque.rs
+++ b/tests/deque.rs
@@ -69,7 +69,9 @@ enum Op {
 }
 
 impl Absorb<Op> for Deque {
-    fn absorb_first(&mut self, operation: &mut Op, _other: &Self) {
+    type Accumulator = ();
+
+    fn absorb_first(&mut self, operation: &mut Op, _other: &Self, _acc: &mut ()) {
         match operation {
             Op::PushBack(value) => {
                 self.push_back(unsafe { value.alias() });
@@ -80,7 +82,7 @@ impl Absorb<Op> for Deque {
         }
     }
 
-    fn absorb_second(&mut self, operation: Op, _other: &Self) {
+    fn absorb_second(&mut self, operation: Op, _other: &Self, _acc: &mut ()) {
         // Cast the data structure to the variant that drops entries.
         // SAFETY: the Aliased type guarantees the same memory layout for NoDrop
         // vs DoDrop, so the cast is sound.


### PR DESCRIPTION
When applying several operations to the same value, certain operations may be faster to compute once at the end rather than incrementally after each change.  E.g. if values are `Vec<u64>`, it would be faster to compute an average or to sort once, after all updates are applied, rather than incrementally after each update.

Add an associated type to the trait for the accumulator, pass it to the absorb methods, and call a new finalize method at the end of each absorb loop.  If not needed, the accumulator can be set to `()` and the finalize method can be left with its default no-op implementation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jonhoo/left-right/138)
<!-- Reviewable:end -->
