### PR TITLE
Relax reentrant nullpointer assumption

### DIFF
--- a/src/read.rs
+++ b/src/read.rs
@@ -134,7 +134,8 @@ impl<T> ReadHandle<T> {
                     t: r_handle,
                 })
             } else {
-                unreachable!("if pointer is null, no ReadGuard should have been issued");
+                // The writer may have dropped while an outer guard keeps this epoch active.
+                None
             };
         }
 


### PR DESCRIPTION
Thanks for your work on left-right!

The reentrant `ReadHandle::enter()` seems to have an `unreachable` assumption that's a bit too strong: `WriteHandle::drop()` can indeed swap the pointer to null while the outer guard keeps the reader epoch active. For instance:
```rust
let (w, r) = left_right::new::<Data, Op>();

let guard = r.enter().unwrap();
let drop_writer = thread::spawn(move || drop(w));

while !r.was_dropped() {
    thread::yield_now();
}

assert!(r.enter().is_none()); // hits unreachable
```

I think returning None suffices here, not sure if you have a better approach in mind.