### PR TITLE
Relax reentrant nullpointer assumption

### DIFF
--- a/src/read.rs
+++ b/src/read.rs
@@ -120,8 +120,7 @@ impl<T> ReadHandle<T> {
     pub fn enter(&self) -> Option<ReadGuard<'_, T>> {
         let enters = self.enters.get();
         if enters != 0 {
-            // We have already locked the epoch.
-            // Just give out another guard.
+            // we have already locked the epoch; just give out another guard.
             let r_handle = self.inner.load(Ordering::Acquire);
             // since we previously bumped our epoch, this pointer will remain valid until we bump
             // it again, which only happens when the last ReadGuard is dropped.
@@ -134,7 +133,11 @@ impl<T> ReadHandle<T> {
                     t: r_handle,
                 })
             } else {
-                unreachable!("if pointer is null, no ReadGuard should have been issued");
+                // WriteHandle must have been dropped, so even though the first `enter` may have
+                // returned `Some`, all we can do now is return `None` since the pointee has
+                // vanished (even if it's still active _somewhere_ since our first enter must be
+                // preventing it from being reclaimed yet).
+                None
             };
         }
 

--- a/tests/counter.rs
+++ b/tests/counter.rs
@@ -1,0 +1,29 @@
+use left_right::Absorb;
+use std::thread;
+
+struct CounterAddOp(i32);
+impl Absorb<CounterAddOp> for i32 {
+    fn absorb_first(&mut self, operation: &mut CounterAddOp, _: &Self) {
+        *self += operation.0;
+    }
+    fn absorb_second(&mut self, operation: CounterAddOp, _: &Self) {
+        *self += operation.0;
+    }
+    fn sync_with(&mut self, first: &Self) {
+        *self = *first
+    }
+}
+
+#[test]
+fn reentrant_enter_during_drop() {
+    let (w, r) = left_right::new::<i32, CounterAddOp>();
+
+    let _guard = r.enter().unwrap();
+    thread::spawn(move || drop(w));
+
+    while !r.was_dropped() {
+        thread::yield_now();
+    }
+
+    assert!(r.enter().is_none());
+}


### PR DESCRIPTION
It's possible for `ReadHandle::enter` to observe `null` even after an initial successful `enter`, specifically when `WriteHandle::drop` is running concurrently, so the `unreachable!` was a little too strong.

Replaces #150 since I wanted to add a test and modify the comments, but the PR did not allow maintainer pushes.