### PR TITLE
Fix ReadHandleFactory auto traits

### DIFF
--- a/src/read.rs
+++ b/src/read.rs
@@ -106,6 +106,7 @@ impl<T> ReadHandle<T> {
         ReadHandleFactory {
             inner: Arc::clone(&self.inner),
             epochs: Arc::clone(&self.epochs),
+            _unimpl_send_sync: PhantomData,
         }
     }
 }

--- a/src/read/factory.rs
+++ b/src/read/factory.rs
@@ -1,17 +1,25 @@
 use super::ReadHandle;
 use crate::sync::{Arc, AtomicPtr};
 use std::fmt;
+use std::marker::PhantomData;
 
-/// A type that is both `Sync` and `Send` and lets you produce new [`ReadHandle`] instances.
+/// A type that lets you produce new [`ReadHandle`] instances.
 ///
 /// This serves as a handy way to distribute read handles across many threads without requiring
 /// additional external locking to synchronize access to the non-`Sync` [`ReadHandle`] type. Note
 /// that this _internally_ takes a lock whenever you call [`ReadHandleFactory::handle`], so
-/// you should not expect producing new handles rapidly to scale well.
+/// you should not expect producing new handles rapidly to scale well. The factory is `Send` and
+/// `Sync` when `T` is `Sync`.
 pub struct ReadHandleFactory<T> {
     pub(super) inner: Arc<AtomicPtr<T>>,
     pub(super) epochs: crate::Epochs,
+    pub(super) _unimpl_send_sync: PhantomData<*const T>,
 }
+
+// Safety: the factory only gives out shared references to T through the handles it creates, so it
+// can cross or be shared across thread boundaries exactly when T is Sync.
+unsafe impl<T> Send for ReadHandleFactory<T> where T: Sync {}
+unsafe impl<T> Sync for ReadHandleFactory<T> where T: Sync {}
 
 impl<T> fmt::Debug for ReadHandleFactory<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -26,6 +34,7 @@ impl<T> Clone for ReadHandleFactory<T> {
         Self {
             inner: Arc::clone(&self.inner),
             epochs: Arc::clone(&self.epochs),
+            _unimpl_send_sync: PhantomData,
         }
     }
 }
@@ -37,3 +46,24 @@ impl<T> ReadHandleFactory<T> {
         ReadHandle::new_with_arc(Arc::clone(&self.inner), Arc::clone(&self.epochs))
     }
 }
+
+/// `ReadHandleFactory` can be sent and shared across threads when `T` is `Sync`:
+///
+/// ```
+/// use left_right::ReadHandleFactory;
+///
+/// fn is_send_sync<T: Send + Sync>() {}
+/// is_send_sync::<ReadHandleFactory<u64>>();
+/// ```
+///
+/// A factory cannot cross thread boundaries when `T` is not `Sync`:
+///
+/// ```compile_fail
+/// use left_right::ReadHandleFactory;
+/// use std::cell::Cell;
+///
+/// fn is_send_sync<T: Send + Sync>() {}
+/// is_send_sync::<ReadHandleFactory<Cell<u64>>>();
+/// ```
+#[allow(dead_code)]
+struct CheckReadHandleFactorySendSync;


### PR DESCRIPTION
## Summary

- prevent `ReadHandleFactory<T>` from auto-implementing `Send` and `Sync` for `T: !Sync`
- explicitly implement both traits when `T: Sync`
- add positive and compile-fail doctests for the auto-trait boundary

## Root cause

The factory only contained `Arc<AtomicPtr<T>>` and the epoch registry, so Rust automatically made it `Send + Sync` without considering whether `T` was `Sync`. Safe code could move a factory for a `Cell`-backed value to another thread, create a second local read handle, and mutate the same `Cell` concurrently. Miri reports that reproducer as a data race.

The private `PhantomData<*const T>` suppresses the unconditional auto-traits, matching the pattern already used by `ReadHandle`. Explicit implementations restore the supported `T: Sync` case.

This intentionally removes auto-trait implementations for instantiations that were previously accepted but unsound, so semver tooling may flag the correction.

## Validation

- `cargo test --offline`
- `cargo fmt --all -- --check`
- the original `ReadHandleFactory<NotSync>` reproducer now fails with `E0277`
